### PR TITLE
Version 0.2.0

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project attempts to match the major and minor versions of [stactools](https://github.com/stac-utils/stactools) and increments the patch number as needed.
 
-## Unreleased
+## 0.2.0
 
 ### Changed
 
+- Modified Item IDs to include product discriminator ([#7](https://github.com/stactools-packages/sentinel2/pull/7))
 - Upgrade to stactools 0.2.1.a2 (supporting PySTAC 1.0.0)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,2 @@
+from setuptools import setup
+setup()

--- a/src/stactools/sentinel2/__init__.py
+++ b/src/stactools/sentinel2/__init__.py
@@ -11,4 +11,4 @@ def register_plugin(registry):
     registry.register_subcommand(commands.create_sentinel2_command)
 
 
-__version__ = '0.1.6'
+__version__ = '0.2.0'


### PR DESCRIPTION
Updates version to 0.2.0 in preparation for a release

Also adds a minimal `setup.py` to allow the `scripts/publish` script to work, which requires setuptools.