### PR TITLE
Add sensor viewing angles

### DIFF
--- a/src/stactools/sentinel2/product_metadata.py
+++ b/src/stactools/sentinel2/product_metadata.py
@@ -97,7 +97,6 @@ class ProductMetadata:
             footprint_polygon = Polygon(footprint_points)
             geometry = mapping(footprint_polygon)
             bbox = footprint_polygon.bounds
-            print(geometry)
             return bbox, geometry
 
         self.bbox, self.geometry = _get_geometries()

--- a/tests/data-files/S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135.SAFE/expected_output.json
+++ b/tests/data-files/S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135",
   "properties": {
-    "created": "2023-02-01T09:04Z",
+    "created": "2023-02-08T13:42Z",
     "providers": [
       {
         "name": "ESA",
@@ -107,6 +107,8 @@
       "href": "./GRANULE/L1C_T01LAC_A026481_20200717T221944/IMG_DATA/T01LAC_20200717T221941_B01.jp2",
       "type": "image/jp2",
       "title": "Coastal aerosol (band 1) - 60m",
+      "view:azimuth": 137.788376577405,
+      "view:incidence_angle": 3.36687397628323,
       "eo:bands": [
         {
           "name": "coastal",
@@ -154,6 +156,8 @@
       "href": "./GRANULE/L1C_T01LAC_A026481_20200717T221944/IMG_DATA/T01LAC_20200717T221941_B02.jp2",
       "type": "image/jp2",
       "title": "Blue (band 2) - 10m",
+      "view:azimuth": 143.988834219607,
+      "view:incidence_angle": 2.73906952611488,
       "eo:bands": [
         {
           "name": "blue",
@@ -201,6 +205,8 @@
       "href": "./GRANULE/L1C_T01LAC_A026481_20200717T221944/IMG_DATA/T01LAC_20200717T221941_B03.jp2",
       "type": "image/jp2",
       "title": "Green (band 3) - 10m",
+      "view:azimuth": 141.349145791963,
+      "view:incidence_angle": 2.8447298082134,
       "eo:bands": [
         {
           "name": "green",
@@ -248,6 +254,8 @@
       "href": "./GRANULE/L1C_T01LAC_A026481_20200717T221944/IMG_DATA/T01LAC_20200717T221941_B04.jp2",
       "type": "image/jp2",
       "title": "Red (band 4) - 10m",
+      "view:azimuth": 139.805379920991,
+      "view:incidence_angle": 2.96168535851192,
       "eo:bands": [
         {
           "name": "red",
@@ -295,6 +303,8 @@
       "href": "./GRANULE/L1C_T01LAC_A026481_20200717T221944/IMG_DATA/T01LAC_20200717T221941_B05.jp2",
       "type": "image/jp2",
       "title": "Red edge 1 (band 5) - 20m",
+      "view:azimuth": 139.166533552428,
+      "view:incidence_angle": 3.03359111894815,
       "eo:bands": [
         {
           "name": "rededge1",
@@ -342,6 +352,8 @@
       "href": "./GRANULE/L1C_T01LAC_A026481_20200717T221944/IMG_DATA/T01LAC_20200717T221941_B06.jp2",
       "type": "image/jp2",
       "title": "Red edge 2 (band 6) - 20m",
+      "view:azimuth": 138.640146836666,
+      "view:incidence_angle": 3.10990527659489,
       "eo:bands": [
         {
           "name": "rededge2",
@@ -389,6 +401,8 @@
       "href": "./GRANULE/L1C_T01LAC_A026481_20200717T221944/IMG_DATA/T01LAC_20200717T221941_B07.jp2",
       "type": "image/jp2",
       "title": "Red edge 3 (band 7) - 20m",
+      "view:azimuth": 138.206766697338,
+      "view:incidence_angle": 3.19048039292866,
       "eo:bands": [
         {
           "name": "rededge3",
@@ -436,6 +450,8 @@
       "href": "./GRANULE/L1C_T01LAC_A026481_20200717T221944/IMG_DATA/T01LAC_20200717T221941_B08.jp2",
       "type": "image/jp2",
       "title": "NIR 1 (band 8) - 10m",
+      "view:azimuth": 142.516303245366,
+      "view:incidence_angle": 2.78846603218996,
       "eo:bands": [
         {
           "name": "nir",
@@ -483,6 +499,8 @@
       "href": "./GRANULE/L1C_T01LAC_A026481_20200717T221944/IMG_DATA/T01LAC_20200717T221941_B8A.jp2",
       "type": "image/jp2",
       "title": "NIR 2 (band 8A) - 20m",
+      "view:azimuth": 137.8481810256,
+      "view:incidence_angle": 3.27449452552853,
       "eo:bands": [
         {
           "name": "nir08",
@@ -530,6 +548,8 @@
       "href": "./GRANULE/L1C_T01LAC_A026481_20200717T221944/IMG_DATA/T01LAC_20200717T221941_B09.jp2",
       "type": "image/jp2",
       "title": "NIR 3 (band 9) - 60m",
+      "view:azimuth": 137.52617922993,
+      "view:incidence_angle": 3.45960801369843,
       "eo:bands": [
         {
           "name": "nir09",
@@ -577,6 +597,8 @@
       "href": "./GRANULE/L1C_T01LAC_A026481_20200717T221944/IMG_DATA/T01LAC_20200717T221941_B10.jp2",
       "type": "image/jp2",
       "title": "Cirrus (band 10) - 60m",
+      "view:azimuth": 140.039893201705,
+      "view:incidence_angle": 2.93310160341489,
       "eo:bands": [
         {
           "name": "cirrus",
@@ -624,6 +646,8 @@
       "href": "./GRANULE/L1C_T01LAC_A026481_20200717T221944/IMG_DATA/T01LAC_20200717T221941_B11.jp2",
       "type": "image/jp2",
       "title": "SWIR 1 (band 11) - 20m",
+      "view:azimuth": 138.291227249188,
+      "view:incidence_angle": 3.10110907911197,
       "eo:bands": [
         {
           "name": "swir16",
@@ -671,6 +695,8 @@
       "href": "./GRANULE/L1C_T01LAC_A026481_20200717T221944/IMG_DATA/T01LAC_20200717T221941_B12.jp2",
       "type": "image/jp2",
       "title": "SWIR 2 (band 12) - 20m",
+      "view:azimuth": 137.363268618098,
+      "view:incidence_angle": 3.29707972874256,
       "eo:bands": [
         {
           "name": "swir22",

--- a/tests/data-files/S2A_MSIL1C_20210908T042701_N0301_R133_T46RER_20210908T070248.SAFE/expected_output.json
+++ b/tests/data-files/S2A_MSIL1C_20210908T042701_N0301_R133_T46RER_20210908T070248.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_MSIL1C_20210908T042701_R133_T46RER_20210908T070248",
   "properties": {
-    "created": "2023-02-01T09:04Z",
+    "created": "2023-02-08T13:42Z",
     "providers": [
       {
         "name": "ESA",
@@ -105,6 +105,8 @@
       "href": "./GRANULE/L1C_T46RER_A032448_20210908T043714/IMG_DATA/T46RER_20210908T042701_B01.jp2",
       "type": "image/jp2",
       "title": "Coastal aerosol (band 1) - 60m",
+      "view:azimuth": 289.941847296065,
+      "view:incidence_angle": 10.6680596147062,
       "eo:bands": [
         {
           "name": "coastal",
@@ -152,6 +154,8 @@
       "href": "./GRANULE/L1C_T46RER_A032448_20210908T043714/IMG_DATA/T46RER_20210908T042701_B02.jp2",
       "type": "image/jp2",
       "title": "Blue (band 2) - 10m",
+      "view:azimuth": 286.158141500527,
+      "view:incidence_angle": 10.4961972020612,
       "eo:bands": [
         {
           "name": "blue",
@@ -199,6 +203,8 @@
       "href": "./GRANULE/L1C_T46RER_A032448_20210908T043714/IMG_DATA/T46RER_20210908T042701_B03.jp2",
       "type": "image/jp2",
       "title": "Green (band 3) - 10m",
+      "view:azimuth": 286.989099353735,
+      "view:incidence_angle": 10.51747402548,
       "eo:bands": [
         {
           "name": "green",
@@ -246,6 +252,8 @@
       "href": "./GRANULE/L1C_T46RER_A032448_20210908T043714/IMG_DATA/T46RER_20210908T042701_B04.jp2",
       "type": "image/jp2",
       "title": "Red (band 4) - 10m",
+      "view:azimuth": 287.732834167769,
+      "view:incidence_angle": 10.5490716177662,
       "eo:bands": [
         {
           "name": "red",
@@ -293,6 +301,8 @@
       "href": "./GRANULE/L1C_T46RER_A032448_20210908T043714/IMG_DATA/T46RER_20210908T042701_B05.jp2",
       "type": "image/jp2",
       "title": "Red edge 1 (band 5) - 20m",
+      "view:azimuth": 288.138981783388,
+      "view:incidence_angle": 10.5659611411428,
       "eo:bands": [
         {
           "name": "rededge1",
@@ -340,6 +350,8 @@
       "href": "./GRANULE/L1C_T46RER_A032448_20210908T043714/IMG_DATA/T46RER_20210908T042701_B06.jp2",
       "type": "image/jp2",
       "title": "Red edge 2 (band 6) - 20m",
+      "view:azimuth": 288.534310726044,
+      "view:incidence_angle": 10.5903273042261,
       "eo:bands": [
         {
           "name": "rededge2",
@@ -387,6 +399,8 @@
       "href": "./GRANULE/L1C_T46RER_A032448_20210908T043714/IMG_DATA/T46RER_20210908T042701_B07.jp2",
       "type": "image/jp2",
       "title": "Red edge 3 (band 7) - 20m",
+      "view:azimuth": 288.938231883591,
+      "view:incidence_angle": 10.6110430881947,
       "eo:bands": [
         {
           "name": "rededge3",
@@ -434,6 +448,8 @@
       "href": "./GRANULE/L1C_T46RER_A032448_20210908T043714/IMG_DATA/T46RER_20210908T042701_B08.jp2",
       "type": "image/jp2",
       "title": "NIR 1 (band 8) - 10m",
+      "view:azimuth": 286.573500443922,
+      "view:incidence_angle": 10.5058743025549,
       "eo:bands": [
         {
           "name": "nir",
@@ -481,6 +497,8 @@
       "href": "./GRANULE/L1C_T46RER_A032448_20210908T043714/IMG_DATA/T46RER_20210908T042701_B8A.jp2",
       "type": "image/jp2",
       "title": "NIR 2 (band 8A) - 20m",
+      "view:azimuth": 289.352095701711,
+      "view:incidence_angle": 10.6338139343661,
       "eo:bands": [
         {
           "name": "nir08",
@@ -528,6 +546,8 @@
       "href": "./GRANULE/L1C_T46RER_A032448_20210908T043714/IMG_DATA/T46RER_20210908T042701_B09.jp2",
       "type": "image/jp2",
       "title": "NIR 3 (band 9) - 60m",
+      "view:azimuth": 290.377170189792,
+      "view:incidence_angle": 10.6951913760532,
       "eo:bands": [
         {
           "name": "nir09",
@@ -575,6 +595,8 @@
       "href": "./GRANULE/L1C_T46RER_A032448_20210908T043714/IMG_DATA/T46RER_20210908T042701_B10.jp2",
       "type": "image/jp2",
       "title": "Cirrus (band 10) - 60m",
+      "view:azimuth": 287.433331935945,
+      "view:incidence_angle": 10.5451892460314,
       "eo:bands": [
         {
           "name": "cirrus",
@@ -622,6 +644,8 @@
       "href": "./GRANULE/L1C_T46RER_A032448_20210908T043714/IMG_DATA/T46RER_20210908T042701_B11.jp2",
       "type": "image/jp2",
       "title": "SWIR 1 (band 11) - 20m",
+      "view:azimuth": 288.431041765834,
+      "view:incidence_angle": 10.5866965903132,
       "eo:bands": [
         {
           "name": "swir16",
@@ -669,6 +693,8 @@
       "href": "./GRANULE/L1C_T46RER_A032448_20210908T043714/IMG_DATA/T46RER_20210908T042701_B12.jp2",
       "type": "image/jp2",
       "title": "SWIR 2 (band 12) - 20m",
+      "view:azimuth": 289.405442997647,
+      "view:incidence_angle": 10.6385476858795,
       "eo:bands": [
         {
           "name": "swir22",

--- a/tests/data-files/S2A_MSIL2A_20190212T192651_N0212_R013_T07HFE_20201007T160857.SAFE/expected_output.json
+++ b/tests/data-files/S2A_MSIL2A_20190212T192651_N0212_R013_T07HFE_20201007T160857.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_MSIL2A_20190212T192651_R013_T07HFE_20201007T160857",
   "properties": {
-    "created": "2023-02-01T09:04Z",
+    "created": "2023-02-08T13:42Z",
     "providers": [
       {
         "name": "ESA",
@@ -113,6 +113,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R20m/T07HFE_20190212T192651_B02_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Blue (band 2) - 20m",
+      "view:azimuth": 286.820822640182,
+      "view:incidence_angle": 10.7227053564162,
       "eo:bands": [
         {
           "name": "blue",
@@ -159,6 +161,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R20m/T07HFE_20190212T192651_B03_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Green (band 3) - 20m",
+      "view:azimuth": 287.66193062313,
+      "view:incidence_angle": 10.7484644698818,
       "eo:bands": [
         {
           "name": "green",
@@ -205,6 +209,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R20m/T07HFE_20190212T192651_B04_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red (band 4) - 20m",
+      "view:azimuth": 288.433166003466,
+      "view:incidence_angle": 10.778802813877,
       "eo:bands": [
         {
           "name": "red",
@@ -251,6 +257,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R20m/T07HFE_20190212T192651_B05_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red edge 1 (band 5) - 20m",
+      "view:azimuth": 288.845299081921,
+      "view:incidence_angle": 10.7978110871057,
       "eo:bands": [
         {
           "name": "rededge1",
@@ -298,6 +306,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R20m/T07HFE_20190212T192651_B06_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red edge 2 (band 6) - 20m",
+      "view:azimuth": 289.271947026448,
+      "view:incidence_angle": 10.819076646934,
       "eo:bands": [
         {
           "name": "rededge2",
@@ -345,6 +355,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R20m/T07HFE_20190212T192651_B07_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red edge 3 (band 7) - 20m",
+      "view:azimuth": 289.683442309859,
+      "view:incidence_angle": 10.8418686954573,
       "eo:bands": [
         {
           "name": "rededge3",
@@ -392,6 +404,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R20m/T07HFE_20190212T192651_B8A_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "NIR 2 (band 8A) - 20m",
+      "view:azimuth": 290.104191276527,
+      "view:incidence_angle": 10.8667503672554,
       "eo:bands": [
         {
           "name": "nir08",
@@ -439,6 +453,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R20m/T07HFE_20190212T192651_B11_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "SWIR 1 (band 11) - 20m",
+      "view:azimuth": 289.168163140243,
+      "view:incidence_angle": 10.8148807894454,
       "eo:bands": [
         {
           "name": "swir16",
@@ -486,6 +502,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R20m/T07HFE_20190212T192651_B12_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "SWIR 2 (band 12) - 20m",
+      "view:azimuth": 290.159788183946,
+      "view:incidence_angle": 10.8717150734,
       "eo:bands": [
         {
           "name": "swir22",
@@ -691,6 +709,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R60m/T07HFE_20190212T192651_B01_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Coastal aerosol (band 1) - 60m",
+      "view:azimuth": 290.48823382165,
+      "view:incidence_angle": 10.8927842996721,
       "eo:bands": [
         {
           "name": "coastal",
@@ -738,6 +758,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R60m/T07HFE_20190212T192651_B02_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Blue (band 2) - 60m",
+      "view:azimuth": 286.820822640182,
+      "view:incidence_angle": 10.7227053564162,
       "eo:bands": [
         {
           "name": "blue",
@@ -784,6 +806,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R60m/T07HFE_20190212T192651_B03_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Green (band 3) - 60m",
+      "view:azimuth": 287.66193062313,
+      "view:incidence_angle": 10.7484644698818,
       "eo:bands": [
         {
           "name": "green",
@@ -830,6 +854,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R60m/T07HFE_20190212T192651_B04_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red (band 4) - 60m",
+      "view:azimuth": 288.433166003466,
+      "view:incidence_angle": 10.778802813877,
       "eo:bands": [
         {
           "name": "red",
@@ -876,6 +902,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R60m/T07HFE_20190212T192651_B05_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red edge 1 (band 5) - 60m",
+      "view:azimuth": 288.845299081921,
+      "view:incidence_angle": 10.7978110871057,
       "eo:bands": [
         {
           "name": "rededge1",
@@ -922,6 +950,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R60m/T07HFE_20190212T192651_B06_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red edge 2 (band 6) - 60m",
+      "view:azimuth": 289.271947026448,
+      "view:incidence_angle": 10.819076646934,
       "eo:bands": [
         {
           "name": "rededge2",
@@ -968,6 +998,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R60m/T07HFE_20190212T192651_B07_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red edge 3 (band 7) - 60m",
+      "view:azimuth": 289.683442309859,
+      "view:incidence_angle": 10.8418686954573,
       "eo:bands": [
         {
           "name": "rededge3",
@@ -1014,6 +1046,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R60m/T07HFE_20190212T192651_B8A_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "NIR 2 (band 8A) - 60m",
+      "view:azimuth": 290.104191276527,
+      "view:incidence_angle": 10.8667503672554,
       "eo:bands": [
         {
           "name": "nir08",
@@ -1060,6 +1094,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R60m/T07HFE_20190212T192651_B09_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "NIR 3 (band 9) - 60m",
+      "view:azimuth": 290.912974638118,
+      "view:incidence_angle": 10.9219716766936,
       "eo:bands": [
         {
           "name": "nir09",
@@ -1107,6 +1143,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R60m/T07HFE_20190212T192651_B11_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "SWIR 1 (band 11) - 60m",
+      "view:azimuth": 289.168163140243,
+      "view:incidence_angle": 10.8148807894454,
       "eo:bands": [
         {
           "name": "swir16",
@@ -1153,6 +1191,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R60m/T07HFE_20190212T192651_B12_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "SWIR 2 (band 12) - 60m",
+      "view:azimuth": 290.159788183946,
+      "view:incidence_angle": 10.8717150734,
       "eo:bands": [
         {
           "name": "swir22",
@@ -1357,6 +1397,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R10m/T07HFE_20190212T192651_B02_10m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Blue (band 2) - 10m",
+      "view:azimuth": 286.820822640182,
+      "view:incidence_angle": 10.7227053564162,
       "eo:bands": [
         {
           "name": "blue",
@@ -1404,6 +1446,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R10m/T07HFE_20190212T192651_B03_10m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Green (band 3) - 10m",
+      "view:azimuth": 287.66193062313,
+      "view:incidence_angle": 10.7484644698818,
       "eo:bands": [
         {
           "name": "green",
@@ -1451,6 +1495,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R10m/T07HFE_20190212T192651_B04_10m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red (band 4) - 10m",
+      "view:azimuth": 288.433166003466,
+      "view:incidence_angle": 10.778802813877,
       "eo:bands": [
         {
           "name": "red",
@@ -1498,6 +1544,8 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/IMG_DATA/R10m/T07HFE_20190212T192651_B08_10m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "NIR 1 (band 8) - 10m",
+      "view:azimuth": 287.241471003298,
+      "view:incidence_angle": 10.734636981112,
       "eo:bands": [
         {
           "name": "nir",

--- a/tests/data-files/S2A_OPER_MSI_L1C_TL_SGS__20181231T203637_A018414_T10SDG/expected_output.json
+++ b/tests/data-files/S2A_OPER_MSI_L1C_TL_SGS__20181231T203637_A018414_T10SDG/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_OPER_MSI_L1C_TL_SGS__20181231T203637_A018414_T10SDG",
   "properties": {
-    "created": "2023-02-01T09:04Z",
+    "created": "2023-02-08T13:42Z",
     "providers": [
       {
         "name": "ESA",
@@ -9951,6 +9951,8 @@
       "href": "./B01.jp2",
       "type": "image/jp2",
       "title": "Coastal aerosol (band 1) - 60m",
+      "view:azimuth": 105.222653658973,
+      "view:incidence_angle": 9.32344350171152,
       "eo:bands": [
         {
           "name": "coastal",
@@ -9998,6 +10000,8 @@
       "href": "./B02.jp2",
       "type": "image/jp2",
       "title": "Blue (band 2) - 10m",
+      "view:azimuth": 103.534530624244,
+      "view:incidence_angle": 9.16046316628897,
       "eo:bands": [
         {
           "name": "blue",
@@ -10045,6 +10049,8 @@
       "href": "./B03.jp2",
       "type": "image/jp2",
       "title": "Green (band 3) - 10m",
+      "view:azimuth": 103.928753911312,
+      "view:incidence_angle": 9.18166424413228,
       "eo:bands": [
         {
           "name": "green",
@@ -10092,6 +10098,8 @@
       "href": "./B04.jp2",
       "type": "image/jp2",
       "title": "Red (band 4) - 10m",
+      "view:azimuth": 104.282145404007,
+      "view:incidence_angle": 9.20898720626288,
       "eo:bands": [
         {
           "name": "red",
@@ -10139,6 +10147,8 @@
       "href": "./B05.jp2",
       "type": "image/jp2",
       "title": "Red edge 1 (band 5) - 20m",
+      "view:azimuth": 104.481053232259,
+      "view:incidence_angle": 9.22703019472298,
       "eo:bands": [
         {
           "name": "rededge1",
@@ -10186,6 +10196,8 @@
       "href": "./B06.jp2",
       "type": "image/jp2",
       "title": "Red edge 2 (band 6) - 20m",
+      "view:azimuth": 104.639978163478,
+      "view:incidence_angle": 9.25101940900086,
       "eo:bands": [
         {
           "name": "rededge2",
@@ -10233,6 +10245,8 @@
       "href": "./B07.jp2",
       "type": "image/jp2",
       "title": "Red edge 3 (band 7) - 20m",
+      "view:azimuth": 104.830111033463,
+      "view:incidence_angle": 9.27342229047768,
       "eo:bands": [
         {
           "name": "rededge3",
@@ -10280,6 +10294,8 @@
       "href": "./B08.jp2",
       "type": "image/jp2",
       "title": "NIR 1 (band 8) - 10m",
+      "view:azimuth": 103.731973628264,
+      "view:incidence_angle": 9.16993618804109,
       "eo:bands": [
         {
           "name": "nir",
@@ -10327,6 +10343,8 @@
       "href": "./B8A.jp2",
       "type": "image/jp2",
       "title": "NIR 2 (band 8A) - 20m",
+      "view:azimuth": 104.971830884209,
+      "view:incidence_angle": 9.30011056604762,
       "eo:bands": [
         {
           "name": "nir08",
@@ -10374,6 +10392,8 @@
       "href": "./B09.jp2",
       "type": "image/jp2",
       "title": "NIR 3 (band 9) - 60m",
+      "view:azimuth": 105.469406889576,
+      "view:incidence_angle": 9.36492818809416,
       "eo:bands": [
         {
           "name": "nir09",
@@ -10421,6 +10441,8 @@
       "href": "./B10.jp2",
       "type": "image/jp2",
       "title": "Cirrus (band 10) - 60m",
+      "view:azimuth": 104.211804645039,
+      "view:incidence_angle": 9.20259833475114,
       "eo:bands": [
         {
           "name": "cirrus",
@@ -10468,6 +10490,8 @@
       "href": "./B11.jp2",
       "type": "image/jp2",
       "title": "SWIR 1 (band 11) - 20m",
+      "view:azimuth": 104.635075782653,
+      "view:incidence_angle": 9.23831368292313,
       "eo:bands": [
         {
           "name": "swir16",
@@ -10515,6 +10539,8 @@
       "href": "./B12.jp2",
       "type": "image/jp2",
       "title": "SWIR 2 (band 12) - 20m",
+      "view:azimuth": 105.032044110384,
+      "view:incidence_angle": 9.29659647868938,
       "eo:bands": [
         {
           "name": "swir22",

--- a/tests/data-files/S2A_OPER_MSI_L2A_TL_SGS__20181231T210250_A018414_T10SDG/expected_output.json
+++ b/tests/data-files/S2A_OPER_MSI_L2A_TL_SGS__20181231T210250_A018414_T10SDG/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_OPER_MSI_L2A_TL_SGS__20181231T210250_A018414_T10SDG",
   "properties": {
-    "created": "2023-02-01T09:04Z",
+    "created": "2023-02-08T13:42Z",
     "providers": [
       {
         "name": "ESA",
@@ -9963,6 +9963,8 @@
       "href": "./R10m/B04.jp2",
       "type": "image/jp2",
       "title": "Red (band 4) - 10m",
+      "view:azimuth": 104.282145404007,
+      "view:incidence_angle": 9.20898720626288,
       "eo:bands": [
         {
           "name": "red",
@@ -10010,6 +10012,8 @@
       "href": "./R10m/B03.jp2",
       "type": "image/jp2",
       "title": "Green (band 3) - 10m",
+      "view:azimuth": 103.928753911312,
+      "view:incidence_angle": 9.18166424413228,
       "eo:bands": [
         {
           "name": "green",
@@ -10057,6 +10061,8 @@
       "href": "./R10m/B02.jp2",
       "type": "image/jp2",
       "title": "Blue (band 2) - 10m",
+      "view:azimuth": 103.534530624244,
+      "view:incidence_angle": 9.16046316628897,
       "eo:bands": [
         {
           "name": "blue",
@@ -10228,6 +10234,8 @@
       "href": "./R10m/B08.jp2",
       "type": "image/jp2",
       "title": "NIR 1 (band 8) - 10m",
+      "view:azimuth": 103.731973628264,
+      "view:incidence_angle": 9.16993618804109,
       "eo:bands": [
         {
           "name": "nir",
@@ -10275,6 +10283,8 @@
       "href": "./R20m/B12.jp2",
       "type": "image/jp2",
       "title": "SWIR 2 (band 12) - 20m",
+      "view:azimuth": 105.032044110384,
+      "view:incidence_angle": 9.29659647868938,
       "eo:bands": [
         {
           "name": "swir22",
@@ -10322,6 +10332,8 @@
       "href": "./R20m/B06.jp2",
       "type": "image/jp2",
       "title": "Red edge 2 (band 6) - 20m",
+      "view:azimuth": 104.639978163478,
+      "view:incidence_angle": 9.25101940900086,
       "eo:bands": [
         {
           "name": "rededge2",
@@ -10369,6 +10381,8 @@
       "href": "./R20m/B07.jp2",
       "type": "image/jp2",
       "title": "Red edge 3 (band 7) - 20m",
+      "view:azimuth": 104.830111033463,
+      "view:incidence_angle": 9.27342229047768,
       "eo:bands": [
         {
           "name": "rededge3",
@@ -10416,6 +10430,8 @@
       "href": "./R20m/B05.jp2",
       "type": "image/jp2",
       "title": "Red edge 1 (band 5) - 20m",
+      "view:azimuth": 104.481053232259,
+      "view:incidence_angle": 9.22703019472298,
       "eo:bands": [
         {
           "name": "rededge1",
@@ -10463,6 +10479,8 @@
       "href": "./R20m/B11.jp2",
       "type": "image/jp2",
       "title": "SWIR 1 (band 11) - 20m",
+      "view:azimuth": 104.635075782653,
+      "view:incidence_angle": 9.23831368292313,
       "eo:bands": [
         {
           "name": "swir16",
@@ -10510,6 +10528,8 @@
       "href": "./R20m/B04.jp2",
       "type": "image/jp2",
       "title": "Red (band 4) - 20m",
+      "view:azimuth": 104.282145404007,
+      "view:incidence_angle": 9.20898720626288,
       "eo:bands": [
         {
           "name": "red",
@@ -10556,6 +10576,8 @@
       "href": "./R20m/B03.jp2",
       "type": "image/jp2",
       "title": "Green (band 3) - 20m",
+      "view:azimuth": 103.928753911312,
+      "view:incidence_angle": 9.18166424413228,
       "eo:bands": [
         {
           "name": "green",
@@ -10602,6 +10624,8 @@
       "href": "./R20m/B02.jp2",
       "type": "image/jp2",
       "title": "Blue (band 2) - 20m",
+      "view:azimuth": 103.534530624244,
+      "view:incidence_angle": 9.16046316628897,
       "eo:bands": [
         {
           "name": "blue",
@@ -10686,6 +10710,8 @@
       "href": "./R20m/B8A.jp2",
       "type": "image/jp2",
       "title": "NIR 2 (band 8A) - 20m",
+      "view:azimuth": 104.971830884209,
+      "view:incidence_angle": 9.30011056604762,
       "eo:bands": [
         {
           "name": "nir08",
@@ -10853,6 +10879,8 @@
       "href": "./R20m/B08.jp2",
       "type": "image/jp2",
       "title": "NIR 1 (band 8) - 20m",
+      "view:azimuth": 103.731973628264,
+      "view:incidence_angle": 9.16993618804109,
       "eo:bands": [
         {
           "name": "nir",
@@ -10899,6 +10927,8 @@
       "href": "./R60m/B12.jp2",
       "type": "image/jp2",
       "title": "SWIR 2 (band 12) - 60m",
+      "view:azimuth": 105.032044110384,
+      "view:incidence_angle": 9.29659647868938,
       "eo:bands": [
         {
           "name": "swir22",
@@ -10945,6 +10975,8 @@
       "href": "./R60m/B06.jp2",
       "type": "image/jp2",
       "title": "Red edge 2 (band 6) - 60m",
+      "view:azimuth": 104.639978163478,
+      "view:incidence_angle": 9.25101940900086,
       "eo:bands": [
         {
           "name": "rededge2",
@@ -10991,6 +11023,8 @@
       "href": "./R60m/B07.jp2",
       "type": "image/jp2",
       "title": "Red edge 3 (band 7) - 60m",
+      "view:azimuth": 104.830111033463,
+      "view:incidence_angle": 9.27342229047768,
       "eo:bands": [
         {
           "name": "rededge3",
@@ -11037,6 +11071,8 @@
       "href": "./R60m/B05.jp2",
       "type": "image/jp2",
       "title": "Red edge 1 (band 5) - 60m",
+      "view:azimuth": 104.481053232259,
+      "view:incidence_angle": 9.22703019472298,
       "eo:bands": [
         {
           "name": "rededge1",
@@ -11083,6 +11119,8 @@
       "href": "./R60m/B11.jp2",
       "type": "image/jp2",
       "title": "SWIR 1 (band 11) - 60m",
+      "view:azimuth": 104.635075782653,
+      "view:incidence_angle": 9.23831368292313,
       "eo:bands": [
         {
           "name": "swir16",
@@ -11129,6 +11167,8 @@
       "href": "./R60m/B04.jp2",
       "type": "image/jp2",
       "title": "Red (band 4) - 60m",
+      "view:azimuth": 104.282145404007,
+      "view:incidence_angle": 9.20898720626288,
       "eo:bands": [
         {
           "name": "red",
@@ -11175,6 +11215,8 @@
       "href": "./R60m/B01.jp2",
       "type": "image/jp2",
       "title": "Coastal aerosol (band 1) - 60m",
+      "view:azimuth": 105.222653658973,
+      "view:incidence_angle": 9.32344350171152,
       "eo:bands": [
         {
           "name": "coastal",
@@ -11222,6 +11264,8 @@
       "href": "./R60m/B03.jp2",
       "type": "image/jp2",
       "title": "Green (band 3) - 60m",
+      "view:azimuth": 103.928753911312,
+      "view:incidence_angle": 9.18166424413228,
       "eo:bands": [
         {
           "name": "green",
@@ -11268,6 +11312,8 @@
       "href": "./R60m/B02.jp2",
       "type": "image/jp2",
       "title": "Blue (band 2) - 60m",
+      "view:azimuth": 103.534530624244,
+      "view:incidence_angle": 9.16046316628897,
       "eo:bands": [
         {
           "name": "blue",
@@ -11352,6 +11398,8 @@
       "href": "./R60m/B8A.jp2",
       "type": "image/jp2",
       "title": "NIR 2 (band 8A) - 60m",
+      "view:azimuth": 104.971830884209,
+      "view:incidence_angle": 9.30011056604762,
       "eo:bands": [
         {
           "name": "nir08",
@@ -11469,6 +11517,8 @@
       "href": "./R60m/B09.jp2",
       "type": "image/jp2",
       "title": "NIR 3 (band 9) - 60m",
+      "view:azimuth": 105.469406889576,
+      "view:incidence_angle": 9.36492818809416,
       "eo:bands": [
         {
           "name": "nir09",
@@ -11565,6 +11615,8 @@
       "href": "./R60m/B08.jp2",
       "type": "image/jp2",
       "title": "NIR 1 (band 8) - 60m",
+      "view:azimuth": 103.731973628264,
+      "view:incidence_angle": 9.16993618804109,
       "eo:bands": [
         {
           "name": "nir",

--- a/tests/data-files/S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBP/expected_output.json
+++ b/tests/data-files/S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBP/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBP",
   "properties": {
-    "created": "2023-02-01T09:04Z",
+    "created": "2023-02-08T13:42Z",
     "providers": [
       {
         "name": "ESA",
@@ -103,6 +103,8 @@
       "href": "./R10m/B04.jp2",
       "type": "image/jp2",
       "title": "Red (band 4) - 10m",
+      "view:azimuth": 99.2910718780649,
+      "view:incidence_angle": 9.62786291597961,
       "eo:bands": [
         {
           "name": "red",
@@ -150,6 +152,8 @@
       "href": "./R10m/B03.jp2",
       "type": "image/jp2",
       "title": "Green (band 3) - 10m",
+      "view:azimuth": 99.6521307443619,
+      "view:incidence_angle": 9.60054008287678,
       "eo:bands": [
         {
           "name": "green",
@@ -197,6 +201,8 @@
       "href": "./R10m/B02.jp2",
       "type": "image/jp2",
       "title": "Blue (band 2) - 10m",
+      "view:azimuth": 100.044220671618,
+      "view:incidence_angle": 9.57891073556407,
       "eo:bands": [
         {
           "name": "blue",
@@ -368,6 +374,8 @@
       "href": "./R10m/B08.jp2",
       "type": "image/jp2",
       "title": "NIR 1 (band 8) - 10m",
+      "view:azimuth": 99.8481402904334,
+      "view:incidence_angle": 9.58866505395536,
       "eo:bands": [
         {
           "name": "nir",
@@ -415,6 +423,8 @@
       "href": "./R20m/B12.jp2",
       "type": "image/jp2",
       "title": "SWIR 2 (band 12) - 20m",
+      "view:azimuth": 98.5099413284717,
+      "view:incidence_angle": 9.7169877722973,
       "eo:bands": [
         {
           "name": "swir22",
@@ -462,6 +472,8 @@
       "href": "./R20m/B06.jp2",
       "type": "image/jp2",
       "title": "Red edge 2 (band 6) - 20m",
+      "view:azimuth": 98.9061010477403,
+      "view:incidence_angle": 9.66556944380412,
       "eo:bands": [
         {
           "name": "rededge2",
@@ -509,6 +521,8 @@
       "href": "./R20m/B07.jp2",
       "type": "image/jp2",
       "title": "Red edge 3 (band 7) - 20m",
+      "view:azimuth": 98.7192006210671,
+      "view:incidence_angle": 9.68751083533581,
       "eo:bands": [
         {
           "name": "rededge3",
@@ -556,6 +570,8 @@
       "href": "./R20m/B05.jp2",
       "type": "image/jp2",
       "title": "Red edge 1 (band 5) - 20m",
+      "view:azimuth": 99.1038246979466,
+      "view:incidence_angle": 9.6456129691341,
       "eo:bands": [
         {
           "name": "rededge1",
@@ -603,6 +619,8 @@
       "href": "./R20m/B11.jp2",
       "type": "image/jp2",
       "title": "SWIR 1 (band 11) - 20m",
+      "view:azimuth": 98.9657292461706,
+      "view:incidence_angle": 9.66207648815742,
       "eo:bands": [
         {
           "name": "swir16",
@@ -650,6 +668,8 @@
       "href": "./R20m/B04.jp2",
       "type": "image/jp2",
       "title": "Red (band 4) - 20m",
+      "view:azimuth": 99.2910718780649,
+      "view:incidence_angle": 9.62786291597961,
       "eo:bands": [
         {
           "name": "red",
@@ -696,6 +716,8 @@
       "href": "./R20m/B03.jp2",
       "type": "image/jp2",
       "title": "Green (band 3) - 20m",
+      "view:azimuth": 99.6521307443619,
+      "view:incidence_angle": 9.60054008287678,
       "eo:bands": [
         {
           "name": "green",
@@ -742,6 +764,8 @@
       "href": "./R20m/B02.jp2",
       "type": "image/jp2",
       "title": "Blue (band 2) - 20m",
+      "view:azimuth": 100.044220671618,
+      "view:incidence_angle": 9.57891073556407,
       "eo:bands": [
         {
           "name": "blue",
@@ -826,6 +850,8 @@
       "href": "./R20m/B8A.jp2",
       "type": "image/jp2",
       "title": "NIR 2 (band 8A) - 20m",
+      "view:azimuth": 98.5245343889886,
+      "view:incidence_angle": 9.71155070045094,
       "eo:bands": [
         {
           "name": "nir08",
@@ -993,6 +1019,8 @@
       "href": "./R20m/B08.jp2",
       "type": "image/jp2",
       "title": "NIR 1 (band 8) - 20m",
+      "view:azimuth": 99.8481402904334,
+      "view:incidence_angle": 9.58866505395536,
       "eo:bands": [
         {
           "name": "nir",
@@ -1039,6 +1067,8 @@
       "href": "./R60m/B12.jp2",
       "type": "image/jp2",
       "title": "SWIR 2 (band 12) - 60m",
+      "view:azimuth": 98.5099413284717,
+      "view:incidence_angle": 9.7169877722973,
       "eo:bands": [
         {
           "name": "swir22",
@@ -1085,6 +1115,8 @@
       "href": "./R60m/B06.jp2",
       "type": "image/jp2",
       "title": "Red edge 2 (band 6) - 60m",
+      "view:azimuth": 98.9061010477403,
+      "view:incidence_angle": 9.66556944380412,
       "eo:bands": [
         {
           "name": "rededge2",
@@ -1131,6 +1163,8 @@
       "href": "./R60m/B07.jp2",
       "type": "image/jp2",
       "title": "Red edge 3 (band 7) - 60m",
+      "view:azimuth": 98.7192006210671,
+      "view:incidence_angle": 9.68751083533581,
       "eo:bands": [
         {
           "name": "rededge3",
@@ -1177,6 +1211,8 @@
       "href": "./R60m/B05.jp2",
       "type": "image/jp2",
       "title": "Red edge 1 (band 5) - 60m",
+      "view:azimuth": 99.1038246979466,
+      "view:incidence_angle": 9.6456129691341,
       "eo:bands": [
         {
           "name": "rededge1",
@@ -1223,6 +1259,8 @@
       "href": "./R60m/B11.jp2",
       "type": "image/jp2",
       "title": "SWIR 1 (band 11) - 60m",
+      "view:azimuth": 98.9657292461706,
+      "view:incidence_angle": 9.66207648815742,
       "eo:bands": [
         {
           "name": "swir16",
@@ -1269,6 +1307,8 @@
       "href": "./R60m/B04.jp2",
       "type": "image/jp2",
       "title": "Red (band 4) - 60m",
+      "view:azimuth": 99.2910718780649,
+      "view:incidence_angle": 9.62786291597961,
       "eo:bands": [
         {
           "name": "red",
@@ -1315,6 +1355,8 @@
       "href": "./R60m/B01.jp2",
       "type": "image/jp2",
       "title": "Coastal aerosol (band 1) - 60m",
+      "view:azimuth": 98.3718393108975,
+      "view:incidence_angle": 9.73744364267219,
       "eo:bands": [
         {
           "name": "coastal",
@@ -1362,6 +1404,8 @@
       "href": "./R60m/B03.jp2",
       "type": "image/jp2",
       "title": "Green (band 3) - 60m",
+      "view:azimuth": 99.6521307443619,
+      "view:incidence_angle": 9.60054008287678,
       "eo:bands": [
         {
           "name": "green",
@@ -1408,6 +1452,8 @@
       "href": "./R60m/B02.jp2",
       "type": "image/jp2",
       "title": "Blue (band 2) - 60m",
+      "view:azimuth": 100.044220671618,
+      "view:incidence_angle": 9.57891073556407,
       "eo:bands": [
         {
           "name": "blue",
@@ -1492,6 +1538,8 @@
       "href": "./R60m/B8A.jp2",
       "type": "image/jp2",
       "title": "NIR 2 (band 8A) - 60m",
+      "view:azimuth": 98.5245343889886,
+      "view:incidence_angle": 9.71155070045094,
       "eo:bands": [
         {
           "name": "nir08",
@@ -1609,6 +1657,8 @@
       "href": "./R60m/B09.jp2",
       "type": "image/jp2",
       "title": "NIR 3 (band 9) - 60m",
+      "view:azimuth": 98.1774485141319,
+      "view:incidence_angle": 9.76624997643779,
       "eo:bands": [
         {
           "name": "nir09",
@@ -1705,6 +1755,8 @@
       "href": "./R60m/B08.jp2",
       "type": "image/jp2",
       "title": "NIR 1 (band 8) - 60m",
+      "view:azimuth": 99.8481402904334,
+      "view:incidence_angle": 9.58866505395536,
       "eo:bands": [
         {
           "name": "nir",

--- a/tests/data-files/S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBQ/expected_output.json
+++ b/tests/data-files/S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBQ/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBQ",
   "properties": {
-    "created": "2023-02-01T09:04Z",
+    "created": "2023-02-08T13:42Z",
     "providers": [
       {
         "name": "ESA",
@@ -110,6 +110,8 @@
       "href": "./R10m/B04.jp2",
       "type": "image/jp2",
       "title": "Red (band 4) - 10m",
+      "view:azimuth": 99.2910718780649,
+      "view:incidence_angle": 9.62786291597961,
       "eo:bands": [
         {
           "name": "red",
@@ -157,6 +159,8 @@
       "href": "./R10m/B03.jp2",
       "type": "image/jp2",
       "title": "Green (band 3) - 10m",
+      "view:azimuth": 99.6521307443619,
+      "view:incidence_angle": 9.60054008287678,
       "eo:bands": [
         {
           "name": "green",
@@ -204,6 +208,8 @@
       "href": "./R10m/B02.jp2",
       "type": "image/jp2",
       "title": "Blue (band 2) - 10m",
+      "view:azimuth": 100.044220671618,
+      "view:incidence_angle": 9.57891073556407,
       "eo:bands": [
         {
           "name": "blue",
@@ -375,6 +381,8 @@
       "href": "./R10m/B08.jp2",
       "type": "image/jp2",
       "title": "NIR 1 (band 8) - 10m",
+      "view:azimuth": 99.8481402904334,
+      "view:incidence_angle": 9.58866505395536,
       "eo:bands": [
         {
           "name": "nir",
@@ -422,6 +430,8 @@
       "href": "./R20m/B12.jp2",
       "type": "image/jp2",
       "title": "SWIR 2 (band 12) - 20m",
+      "view:azimuth": 98.5099413284717,
+      "view:incidence_angle": 9.7169877722973,
       "eo:bands": [
         {
           "name": "swir22",
@@ -469,6 +479,8 @@
       "href": "./R20m/B06.jp2",
       "type": "image/jp2",
       "title": "Red edge 2 (band 6) - 20m",
+      "view:azimuth": 98.9061010477403,
+      "view:incidence_angle": 9.66556944380412,
       "eo:bands": [
         {
           "name": "rededge2",
@@ -516,6 +528,8 @@
       "href": "./R20m/B07.jp2",
       "type": "image/jp2",
       "title": "Red edge 3 (band 7) - 20m",
+      "view:azimuth": 98.7192006210671,
+      "view:incidence_angle": 9.68751083533581,
       "eo:bands": [
         {
           "name": "rededge3",
@@ -563,6 +577,8 @@
       "href": "./R20m/B05.jp2",
       "type": "image/jp2",
       "title": "Red edge 1 (band 5) - 20m",
+      "view:azimuth": 99.1038246979466,
+      "view:incidence_angle": 9.6456129691341,
       "eo:bands": [
         {
           "name": "rededge1",
@@ -610,6 +626,8 @@
       "href": "./R20m/B11.jp2",
       "type": "image/jp2",
       "title": "SWIR 1 (band 11) - 20m",
+      "view:azimuth": 98.9657292461706,
+      "view:incidence_angle": 9.66207648815742,
       "eo:bands": [
         {
           "name": "swir16",
@@ -657,6 +675,8 @@
       "href": "./R20m/B04.jp2",
       "type": "image/jp2",
       "title": "Red (band 4) - 20m",
+      "view:azimuth": 99.2910718780649,
+      "view:incidence_angle": 9.62786291597961,
       "eo:bands": [
         {
           "name": "red",
@@ -703,6 +723,8 @@
       "href": "./R20m/B03.jp2",
       "type": "image/jp2",
       "title": "Green (band 3) - 20m",
+      "view:azimuth": 99.6521307443619,
+      "view:incidence_angle": 9.60054008287678,
       "eo:bands": [
         {
           "name": "green",
@@ -749,6 +771,8 @@
       "href": "./R20m/B02.jp2",
       "type": "image/jp2",
       "title": "Blue (band 2) - 20m",
+      "view:azimuth": 100.044220671618,
+      "view:incidence_angle": 9.57891073556407,
       "eo:bands": [
         {
           "name": "blue",
@@ -833,6 +857,8 @@
       "href": "./R20m/B8A.jp2",
       "type": "image/jp2",
       "title": "NIR 2 (band 8A) - 20m",
+      "view:azimuth": 98.5245343889886,
+      "view:incidence_angle": 9.71155070045094,
       "eo:bands": [
         {
           "name": "nir08",
@@ -1000,6 +1026,8 @@
       "href": "./R20m/B08.jp2",
       "type": "image/jp2",
       "title": "NIR 1 (band 8) - 20m",
+      "view:azimuth": 99.8481402904334,
+      "view:incidence_angle": 9.58866505395536,
       "eo:bands": [
         {
           "name": "nir",
@@ -1046,6 +1074,8 @@
       "href": "./R60m/B12.jp2",
       "type": "image/jp2",
       "title": "SWIR 2 (band 12) - 60m",
+      "view:azimuth": 98.5099413284717,
+      "view:incidence_angle": 9.7169877722973,
       "eo:bands": [
         {
           "name": "swir22",
@@ -1092,6 +1122,8 @@
       "href": "./R60m/B06.jp2",
       "type": "image/jp2",
       "title": "Red edge 2 (band 6) - 60m",
+      "view:azimuth": 98.9061010477403,
+      "view:incidence_angle": 9.66556944380412,
       "eo:bands": [
         {
           "name": "rededge2",
@@ -1138,6 +1170,8 @@
       "href": "./R60m/B07.jp2",
       "type": "image/jp2",
       "title": "Red edge 3 (band 7) - 60m",
+      "view:azimuth": 98.7192006210671,
+      "view:incidence_angle": 9.68751083533581,
       "eo:bands": [
         {
           "name": "rededge3",
@@ -1184,6 +1218,8 @@
       "href": "./R60m/B05.jp2",
       "type": "image/jp2",
       "title": "Red edge 1 (band 5) - 60m",
+      "view:azimuth": 99.1038246979466,
+      "view:incidence_angle": 9.6456129691341,
       "eo:bands": [
         {
           "name": "rededge1",
@@ -1230,6 +1266,8 @@
       "href": "./R60m/B11.jp2",
       "type": "image/jp2",
       "title": "SWIR 1 (band 11) - 60m",
+      "view:azimuth": 98.9657292461706,
+      "view:incidence_angle": 9.66207648815742,
       "eo:bands": [
         {
           "name": "swir16",
@@ -1276,6 +1314,8 @@
       "href": "./R60m/B04.jp2",
       "type": "image/jp2",
       "title": "Red (band 4) - 60m",
+      "view:azimuth": 99.2910718780649,
+      "view:incidence_angle": 9.62786291597961,
       "eo:bands": [
         {
           "name": "red",
@@ -1322,6 +1362,8 @@
       "href": "./R60m/B01.jp2",
       "type": "image/jp2",
       "title": "Coastal aerosol (band 1) - 60m",
+      "view:azimuth": 98.3718393108975,
+      "view:incidence_angle": 9.73744364267219,
       "eo:bands": [
         {
           "name": "coastal",
@@ -1369,6 +1411,8 @@
       "href": "./R60m/B03.jp2",
       "type": "image/jp2",
       "title": "Green (band 3) - 60m",
+      "view:azimuth": 99.6521307443619,
+      "view:incidence_angle": 9.60054008287678,
       "eo:bands": [
         {
           "name": "green",
@@ -1415,6 +1459,8 @@
       "href": "./R60m/B02.jp2",
       "type": "image/jp2",
       "title": "Blue (band 2) - 60m",
+      "view:azimuth": 100.044220671618,
+      "view:incidence_angle": 9.57891073556407,
       "eo:bands": [
         {
           "name": "blue",
@@ -1499,6 +1545,8 @@
       "href": "./R60m/B8A.jp2",
       "type": "image/jp2",
       "title": "NIR 2 (band 8A) - 60m",
+      "view:azimuth": 98.5245343889886,
+      "view:incidence_angle": 9.71155070045094,
       "eo:bands": [
         {
           "name": "nir08",
@@ -1616,6 +1664,8 @@
       "href": "./R60m/B09.jp2",
       "type": "image/jp2",
       "title": "NIR 3 (band 9) - 60m",
+      "view:azimuth": 98.1774485141319,
+      "view:incidence_angle": 9.76624997643779,
       "eo:bands": [
         {
           "name": "nir09",
@@ -1712,6 +1762,8 @@
       "href": "./R60m/B08.jp2",
       "type": "image/jp2",
       "title": "NIR 1 (band 8) - 60m",
+      "view:azimuth": 99.8481402904334,
+      "view:incidence_angle": 9.58866505395536,
       "eo:bands": [
         {
           "name": "nir",

--- a/tests/data-files/S2B_MSIL2A_20191228T210519_N0212_R071_T01CCV_20201003T104658.SAFE/expected_output.json
+++ b/tests/data-files/S2B_MSIL2A_20191228T210519_N0212_R071_T01CCV_20201003T104658.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2B_MSIL2A_20191228T210519_R071_T01CCV_20201003T104658",
   "properties": {
-    "created": "2023-02-01T09:04Z",
+    "created": "2023-02-08T13:42Z",
     "providers": [
       {
         "name": "ESA",
@@ -129,6 +129,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R20m/T01CCV_20191228T210519_B02_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Blue (band 2) - 20m",
+      "view:azimuth": 299.520631476454,
+      "view:incidence_angle": 10.7985970063199,
       "eo:bands": [
         {
           "name": "blue",
@@ -175,6 +177,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R20m/T01CCV_20191228T210519_B03_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Green (band 3) - 20m",
+      "view:azimuth": 300.497757463677,
+      "view:incidence_angle": 10.822233080032,
       "eo:bands": [
         {
           "name": "green",
@@ -221,6 +225,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R20m/T01CCV_20191228T210519_B04_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red (band 4) - 20m",
+      "view:azimuth": 301.398604018607,
+      "view:incidence_angle": 10.8507073259669,
       "eo:bands": [
         {
           "name": "red",
@@ -267,6 +273,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R20m/T01CCV_20191228T210519_B05_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red edge 1 (band 5) - 20m",
+      "view:azimuth": 301.880666343481,
+      "view:incidence_angle": 10.8687158186137,
       "eo:bands": [
         {
           "name": "rededge1",
@@ -314,6 +322,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R20m/T01CCV_20191228T210519_B06_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red edge 2 (band 6) - 20m",
+      "view:azimuth": 302.374527614989,
+      "view:incidence_angle": 10.8888434410565,
       "eo:bands": [
         {
           "name": "rededge2",
@@ -361,6 +371,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R20m/T01CCV_20191228T210519_B07_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red edge 3 (band 7) - 20m",
+      "view:azimuth": 302.874609684129,
+      "view:incidence_angle": 10.9204140720004,
       "eo:bands": [
         {
           "name": "rededge3",
@@ -408,6 +420,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R20m/T01CCV_20191228T210519_B8A_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "NIR 2 (band 8A) - 20m",
+      "view:azimuth": 303.366040038463,
+      "view:incidence_angle": 10.9442443310732,
       "eo:bands": [
         {
           "name": "nir08",
@@ -455,6 +469,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R20m/T01CCV_20191228T210519_B11_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "SWIR 1 (band 11) - 20m",
+      "view:azimuth": 302.24300991018,
+      "view:incidence_angle": 10.8845308415639,
       "eo:bands": [
         {
           "name": "swir16",
@@ -502,6 +518,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R20m/T01CCV_20191228T210519_B12_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "SWIR 2 (band 12) - 20m",
+      "view:azimuth": 303.42008542786,
+      "view:incidence_angle": 10.9485408965834,
       "eo:bands": [
         {
           "name": "swir22",
@@ -707,6 +725,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R60m/T01CCV_20191228T210519_B01_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Coastal aerosol (band 1) - 60m",
+      "view:azimuth": 303.825599018102,
+      "view:incidence_angle": 10.9693522443217,
       "eo:bands": [
         {
           "name": "coastal",
@@ -754,6 +774,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R60m/T01CCV_20191228T210519_B02_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Blue (band 2) - 60m",
+      "view:azimuth": 299.520631476454,
+      "view:incidence_angle": 10.7985970063199,
       "eo:bands": [
         {
           "name": "blue",
@@ -800,6 +822,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R60m/T01CCV_20191228T210519_B03_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Green (band 3) - 60m",
+      "view:azimuth": 300.497757463677,
+      "view:incidence_angle": 10.822233080032,
       "eo:bands": [
         {
           "name": "green",
@@ -846,6 +870,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R60m/T01CCV_20191228T210519_B04_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red (band 4) - 60m",
+      "view:azimuth": 301.398604018607,
+      "view:incidence_angle": 10.8507073259669,
       "eo:bands": [
         {
           "name": "red",
@@ -892,6 +918,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R60m/T01CCV_20191228T210519_B05_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red edge 1 (band 5) - 60m",
+      "view:azimuth": 301.880666343481,
+      "view:incidence_angle": 10.8687158186137,
       "eo:bands": [
         {
           "name": "rededge1",
@@ -938,6 +966,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R60m/T01CCV_20191228T210519_B06_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red edge 2 (band 6) - 60m",
+      "view:azimuth": 302.374527614989,
+      "view:incidence_angle": 10.8888434410565,
       "eo:bands": [
         {
           "name": "rededge2",
@@ -984,6 +1014,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R60m/T01CCV_20191228T210519_B07_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red edge 3 (band 7) - 60m",
+      "view:azimuth": 302.874609684129,
+      "view:incidence_angle": 10.9204140720004,
       "eo:bands": [
         {
           "name": "rededge3",
@@ -1030,6 +1062,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R60m/T01CCV_20191228T210519_B8A_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "NIR 2 (band 8A) - 60m",
+      "view:azimuth": 303.366040038463,
+      "view:incidence_angle": 10.9442443310732,
       "eo:bands": [
         {
           "name": "nir08",
@@ -1076,6 +1110,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R60m/T01CCV_20191228T210519_B09_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "NIR 3 (band 9) - 60m",
+      "view:azimuth": 304.325095060087,
+      "view:incidence_angle": 10.9975598362208,
       "eo:bands": [
         {
           "name": "nir09",
@@ -1123,6 +1159,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R60m/T01CCV_20191228T210519_B11_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "SWIR 1 (band 11) - 60m",
+      "view:azimuth": 302.24300991018,
+      "view:incidence_angle": 10.8845308415639,
       "eo:bands": [
         {
           "name": "swir16",
@@ -1169,6 +1207,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R60m/T01CCV_20191228T210519_B12_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "SWIR 2 (band 12) - 60m",
+      "view:azimuth": 303.42008542786,
+      "view:incidence_angle": 10.9485408965834,
       "eo:bands": [
         {
           "name": "swir22",
@@ -1373,6 +1413,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R10m/T01CCV_20191228T210519_B02_10m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Blue (band 2) - 10m",
+      "view:azimuth": 299.520631476454,
+      "view:incidence_angle": 10.7985970063199,
       "eo:bands": [
         {
           "name": "blue",
@@ -1420,6 +1462,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R10m/T01CCV_20191228T210519_B03_10m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Green (band 3) - 10m",
+      "view:azimuth": 300.497757463677,
+      "view:incidence_angle": 10.822233080032,
       "eo:bands": [
         {
           "name": "green",
@@ -1467,6 +1511,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R10m/T01CCV_20191228T210519_B04_10m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red (band 4) - 10m",
+      "view:azimuth": 301.398604018607,
+      "view:incidence_angle": 10.8507073259669,
       "eo:bands": [
         {
           "name": "red",
@@ -1514,6 +1560,8 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/IMG_DATA/R10m/T01CCV_20191228T210519_B08_10m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "NIR 1 (band 8) - 10m",
+      "view:azimuth": 300.008008590281,
+      "view:incidence_angle": 10.8094588480691,
       "eo:bands": [
         {
           "name": "nir",

--- a/tests/data-files/S2B_MSIL2A_20220413T150759_N0400_R025_T33XWJ_20220414T082126.SAFE/expected_output.json
+++ b/tests/data-files/S2B_MSIL2A_20220413T150759_N0400_R025_T33XWJ_20220414T082126.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2B_MSIL2A_20220413T150759_R025_T33XWJ_20220414T082126",
   "properties": {
-    "created": "2023-02-01T09:04Z",
+    "created": "2023-02-08T13:42Z",
     "providers": [
       {
         "name": "ESA",
@@ -101,6 +101,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R20m/T33XWJ_20220413T150759_B01_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Coastal aerosol (band 1) - 20m",
+      "view:azimuth": 6.06419195770833,
+      "view:incidence_angle": 11.7620353909695,
       "eo:bands": [
         {
           "name": "coastal",
@@ -147,6 +149,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R20m/T33XWJ_20220413T150759_B02_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Blue (band 2) - 20m",
+      "view:azimuth": 190.524652558141,
+      "view:incidence_angle": 11.5992075739816,
       "eo:bands": [
         {
           "name": "blue",
@@ -193,6 +197,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R20m/T33XWJ_20220413T150759_B03_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Green (band 3) - 20m",
+      "view:azimuth": 43.6918196259253,
+      "view:incidence_angle": 11.6214587470268,
       "eo:bands": [
         {
           "name": "green",
@@ -239,6 +245,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R20m/T33XWJ_20220413T150759_B04_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red (band 4) - 20m",
+      "view:azimuth": 2.63241128145128,
+      "view:incidence_angle": 11.6481293133163,
       "eo:bands": [
         {
           "name": "red",
@@ -285,6 +293,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R20m/T33XWJ_20220413T150759_B05_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red edge 1 (band 5) - 20m",
+      "view:azimuth": 3.32772811467303,
+      "view:incidence_angle": 11.66492198486,
       "eo:bands": [
         {
           "name": "rededge1",
@@ -332,6 +342,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R20m/T33XWJ_20220413T150759_B06_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red edge 2 (band 6) - 20m",
+      "view:azimuth": 4.0337910178607,
+      "view:incidence_angle": 11.6837550910421,
       "eo:bands": [
         {
           "name": "rededge2",
@@ -379,6 +391,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R20m/T33XWJ_20220413T150759_B07_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red edge 3 (band 7) - 20m",
+      "view:azimuth": 4.68954745033689,
+      "view:incidence_angle": 11.7166729061528,
       "eo:bands": [
         {
           "name": "rededge3",
@@ -426,6 +440,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R20m/T33XWJ_20220413T150759_B8A_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "NIR 2 (band 8A) - 20m",
+      "view:azimuth": 5.38993428501136,
+      "view:incidence_angle": 11.7389275451637,
       "eo:bands": [
         {
           "name": "nir08",
@@ -473,6 +489,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R20m/T33XWJ_20220413T150759_B11_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "SWIR 1 (band 11) - 20m",
+      "view:azimuth": 3.87362664850673,
+      "view:incidence_angle": 11.6793252487108,
       "eo:bands": [
         {
           "name": "swir16",
@@ -520,6 +538,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R20m/T33XWJ_20220413T150759_B12_20m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "SWIR 2 (band 12) - 20m",
+      "view:azimuth": 5.4951676207821,
+      "view:incidence_angle": 11.7424271517159,
       "eo:bands": [
         {
           "name": "swir22",
@@ -725,6 +745,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R60m/T33XWJ_20220413T150759_B01_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Coastal aerosol (band 1) - 60m",
+      "view:azimuth": 6.06419195770833,
+      "view:incidence_angle": 11.7620353909695,
       "eo:bands": [
         {
           "name": "coastal",
@@ -772,6 +794,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R60m/T33XWJ_20220413T150759_B02_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Blue (band 2) - 60m",
+      "view:azimuth": 190.524652558141,
+      "view:incidence_angle": 11.5992075739816,
       "eo:bands": [
         {
           "name": "blue",
@@ -818,6 +842,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R60m/T33XWJ_20220413T150759_B03_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Green (band 3) - 60m",
+      "view:azimuth": 43.6918196259253,
+      "view:incidence_angle": 11.6214587470268,
       "eo:bands": [
         {
           "name": "green",
@@ -864,6 +890,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R60m/T33XWJ_20220413T150759_B04_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red (band 4) - 60m",
+      "view:azimuth": 2.63241128145128,
+      "view:incidence_angle": 11.6481293133163,
       "eo:bands": [
         {
           "name": "red",
@@ -910,6 +938,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R60m/T33XWJ_20220413T150759_B05_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red edge 1 (band 5) - 60m",
+      "view:azimuth": 3.32772811467303,
+      "view:incidence_angle": 11.66492198486,
       "eo:bands": [
         {
           "name": "rededge1",
@@ -956,6 +986,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R60m/T33XWJ_20220413T150759_B06_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red edge 2 (band 6) - 60m",
+      "view:azimuth": 4.0337910178607,
+      "view:incidence_angle": 11.6837550910421,
       "eo:bands": [
         {
           "name": "rededge2",
@@ -1002,6 +1034,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R60m/T33XWJ_20220413T150759_B07_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red edge 3 (band 7) - 60m",
+      "view:azimuth": 4.68954745033689,
+      "view:incidence_angle": 11.7166729061528,
       "eo:bands": [
         {
           "name": "rededge3",
@@ -1048,6 +1082,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R60m/T33XWJ_20220413T150759_B8A_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "NIR 2 (band 8A) - 60m",
+      "view:azimuth": 5.38993428501136,
+      "view:incidence_angle": 11.7389275451637,
       "eo:bands": [
         {
           "name": "nir08",
@@ -1094,6 +1130,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R60m/T33XWJ_20220413T150759_B09_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "NIR 3 (band 9) - 60m",
+      "view:azimuth": 6.77720061120476,
+      "view:incidence_angle": 11.7883373938612,
       "eo:bands": [
         {
           "name": "nir09",
@@ -1141,6 +1179,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R60m/T33XWJ_20220413T150759_B11_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "SWIR 1 (band 11) - 60m",
+      "view:azimuth": 3.87362664850673,
+      "view:incidence_angle": 11.6793252487108,
       "eo:bands": [
         {
           "name": "swir16",
@@ -1187,6 +1227,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R60m/T33XWJ_20220413T150759_B12_60m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "SWIR 2 (band 12) - 60m",
+      "view:azimuth": 5.4951676207821,
+      "view:incidence_angle": 11.7424271517159,
       "eo:bands": [
         {
           "name": "swir22",
@@ -1391,6 +1433,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R10m/T33XWJ_20220413T150759_B02_10m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Blue (band 2) - 10m",
+      "view:azimuth": 190.524652558141,
+      "view:incidence_angle": 11.5992075739816,
       "eo:bands": [
         {
           "name": "blue",
@@ -1438,6 +1482,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R10m/T33XWJ_20220413T150759_B03_10m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Green (band 3) - 10m",
+      "view:azimuth": 43.6918196259253,
+      "view:incidence_angle": 11.6214587470268,
       "eo:bands": [
         {
           "name": "green",
@@ -1485,6 +1531,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R10m/T33XWJ_20220413T150759_B04_10m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Red (band 4) - 10m",
+      "view:azimuth": 2.63241128145128,
+      "view:incidence_angle": 11.6481293133163,
       "eo:bands": [
         {
           "name": "red",
@@ -1532,6 +1580,8 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/IMG_DATA/R10m/T33XWJ_20220413T150759_B08_10m.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "NIR 1 (band 8) - 10m",
+      "view:azimuth": 127.695293780521,
+      "view:incidence_angle": 11.6094519193978,
       "eo:bands": [
         {
           "name": "nir",

--- a/tests/data-files/esa_S2B_MSIL2A_20210122T133229_N0214_R081_T22HBD_20210122T155500.SAFE/expected_output.json
+++ b/tests/data-files/esa_S2B_MSIL2A_20210122T133229_N0214_R081_T22HBD_20210122T155500.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2B_MSIL2A_20210122T133229_R081_T22HBD_20210122T155500",
   "properties": {
-    "created": "2023-02-01T09:04Z",
+    "created": "2023-02-08T13:42Z",
     "providers": [
       {
         "name": "ESA",
@@ -133,6 +133,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R10m/T22HBD_20210122T133229_B02_10m.jp2",
       "type": "image/jp2",
       "title": "Blue (band 2) - 10m",
+      "view:azimuth": 286.074405155311,
+      "view:incidence_angle": 7.14151256340819,
       "eo:bands": [
         {
           "name": "blue",
@@ -180,6 +182,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R10m/T22HBD_20210122T133229_B03_10m.jp2",
       "type": "image/jp2",
       "title": "Green (band 3) - 10m",
+      "view:azimuth": 286.396871324483,
+      "view:incidence_angle": 7.16980994548905,
       "eo:bands": [
         {
           "name": "green",
@@ -227,6 +231,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R10m/T22HBD_20210122T133229_B04_10m.jp2",
       "type": "image/jp2",
       "title": "Red (band 4) - 10m",
+      "view:azimuth": 286.680542227333,
+      "view:incidence_angle": 7.21156644976283,
       "eo:bands": [
         {
           "name": "red",
@@ -274,6 +280,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R10m/T22HBD_20210122T133229_B08_10m.jp2",
       "type": "image/jp2",
       "title": "NIR 1 (band 8) - 10m",
+      "view:azimuth": 286.240226618336,
+      "view:incidence_angle": 7.15647126700093,
       "eo:bands": [
         {
           "name": "nir",
@@ -445,6 +453,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R20m/T22HBD_20210122T133229_B02_20m.jp2",
       "type": "image/jp2",
       "title": "Blue (band 2) - 20m",
+      "view:azimuth": 286.074405155311,
+      "view:incidence_angle": 7.14151256340819,
       "eo:bands": [
         {
           "name": "blue",
@@ -491,6 +501,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R20m/T22HBD_20210122T133229_B03_20m.jp2",
       "type": "image/jp2",
       "title": "Green (band 3) - 20m",
+      "view:azimuth": 286.396871324483,
+      "view:incidence_angle": 7.16980994548905,
       "eo:bands": [
         {
           "name": "green",
@@ -537,6 +549,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R20m/T22HBD_20210122T133229_B04_20m.jp2",
       "type": "image/jp2",
       "title": "Red (band 4) - 20m",
+      "view:azimuth": 286.680542227333,
+      "view:incidence_angle": 7.21156644976283,
       "eo:bands": [
         {
           "name": "red",
@@ -583,6 +597,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R20m/T22HBD_20210122T133229_B05_20m.jp2",
       "type": "image/jp2",
       "title": "Red edge 1 (band 5) - 20m",
+      "view:azimuth": 286.795948088286,
+      "view:incidence_angle": 7.24080454661153,
       "eo:bands": [
         {
           "name": "rededge1",
@@ -630,6 +646,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R20m/T22HBD_20210122T133229_B06_20m.jp2",
       "type": "image/jp2",
       "title": "Red edge 2 (band 6) - 20m",
+      "view:azimuth": 286.967386167208,
+      "view:incidence_angle": 7.27362918802462,
       "eo:bands": [
         {
           "name": "rededge2",
@@ -677,6 +695,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R20m/T22HBD_20210122T133229_B07_20m.jp2",
       "type": "image/jp2",
       "title": "Red edge 3 (band 7) - 20m",
+      "view:azimuth": 287.080409708228,
+      "view:incidence_angle": 7.30187431748423,
       "eo:bands": [
         {
           "name": "rededge3",
@@ -724,6 +744,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R20m/T22HBD_20210122T133229_B8A_20m.jp2",
       "type": "image/jp2",
       "title": "NIR 2 (band 8A) - 20m",
+      "view:azimuth": 287.250065936051,
+      "view:incidence_angle": 7.33453903497294,
       "eo:bands": [
         {
           "name": "nir08",
@@ -771,6 +793,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R20m/T22HBD_20210122T133229_B11_20m.jp2",
       "type": "image/jp2",
       "title": "SWIR 1 (band 11) - 20m",
+      "view:azimuth": 286.854252566228,
+      "view:incidence_angle": 7.26833639031408,
       "eo:bands": [
         {
           "name": "swir16",
@@ -818,6 +842,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R20m/T22HBD_20210122T133229_B12_20m.jp2",
       "type": "image/jp2",
       "title": "SWIR 2 (band 12) - 20m",
+      "view:azimuth": 287.188134747138,
+      "view:incidence_angle": 7.3425368804326,
       "eo:bands": [
         {
           "name": "swir22",
@@ -1023,6 +1049,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R60m/T22HBD_20210122T133229_B01_60m.jp2",
       "type": "image/jp2",
       "title": "Coastal aerosol (band 1) - 60m",
+      "view:azimuth": 287.297952970144,
+      "view:incidence_angle": 7.37191461261322,
       "eo:bands": [
         {
           "name": "coastal",
@@ -1070,6 +1098,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R60m/T22HBD_20210122T133229_B02_60m.jp2",
       "type": "image/jp2",
       "title": "Blue (band 2) - 60m",
+      "view:azimuth": 286.074405155311,
+      "view:incidence_angle": 7.14151256340819,
       "eo:bands": [
         {
           "name": "blue",
@@ -1116,6 +1146,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R60m/T22HBD_20210122T133229_B03_60m.jp2",
       "type": "image/jp2",
       "title": "Green (band 3) - 60m",
+      "view:azimuth": 286.396871324483,
+      "view:incidence_angle": 7.16980994548905,
       "eo:bands": [
         {
           "name": "green",
@@ -1162,6 +1194,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R60m/T22HBD_20210122T133229_B04_60m.jp2",
       "type": "image/jp2",
       "title": "Red (band 4) - 60m",
+      "view:azimuth": 286.680542227333,
+      "view:incidence_angle": 7.21156644976283,
       "eo:bands": [
         {
           "name": "red",
@@ -1208,6 +1242,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R60m/T22HBD_20210122T133229_B05_60m.jp2",
       "type": "image/jp2",
       "title": "Red edge 1 (band 5) - 60m",
+      "view:azimuth": 286.795948088286,
+      "view:incidence_angle": 7.24080454661153,
       "eo:bands": [
         {
           "name": "rededge1",
@@ -1254,6 +1290,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R60m/T22HBD_20210122T133229_B06_60m.jp2",
       "type": "image/jp2",
       "title": "Red edge 2 (band 6) - 60m",
+      "view:azimuth": 286.967386167208,
+      "view:incidence_angle": 7.27362918802462,
       "eo:bands": [
         {
           "name": "rededge2",
@@ -1300,6 +1338,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R60m/T22HBD_20210122T133229_B07_60m.jp2",
       "type": "image/jp2",
       "title": "Red edge 3 (band 7) - 60m",
+      "view:azimuth": 287.080409708228,
+      "view:incidence_angle": 7.30187431748423,
       "eo:bands": [
         {
           "name": "rededge3",
@@ -1346,6 +1386,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R60m/T22HBD_20210122T133229_B8A_60m.jp2",
       "type": "image/jp2",
       "title": "NIR 2 (band 8A) - 60m",
+      "view:azimuth": 287.250065936051,
+      "view:incidence_angle": 7.33453903497294,
       "eo:bands": [
         {
           "name": "nir08",
@@ -1392,6 +1434,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R60m/T22HBD_20210122T133229_B09_60m.jp2",
       "type": "image/jp2",
       "title": "NIR 3 (band 9) - 60m",
+      "view:azimuth": 287.418082205282,
+      "view:incidence_angle": 7.41467163276647,
       "eo:bands": [
         {
           "name": "nir09",
@@ -1439,6 +1483,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R60m/T22HBD_20210122T133229_B11_60m.jp2",
       "type": "image/jp2",
       "title": "SWIR 1 (band 11) - 60m",
+      "view:azimuth": 286.854252566228,
+      "view:incidence_angle": 7.26833639031408,
       "eo:bands": [
         {
           "name": "swir16",
@@ -1485,6 +1531,8 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/IMG_DATA/R60m/T22HBD_20210122T133229_B12_60m.jp2",
       "type": "image/jp2",
       "title": "SWIR 2 (band 12) - 60m",
+      "view:azimuth": 287.188134747138,
+      "view:incidence_angle": 7.3425368804326,
       "eo:bands": [
         {
           "name": "swir22",


### PR DESCRIPTION
## Description

Uses `Mean_Viewing_Incidence_Angle_List` in the granule metadata to add sensor azimuth and zenith to each asset, when available.

Requesting @matthewhanson's review to check the following:
- That I'm using the `view` extension correctly
- That I'm doing the `bandId` (which are just integers) to `band` (strings, including `8A`) correctly

## Related issues

- Closes #50 

