### PR TITLE
fix thumbnail_href for SAFE L1C

### DIFF
--- a/src/stactools/sentinel2/safe_manifest.py
+++ b/src/stactools/sentinel2/safe_manifest.py
@@ -46,6 +46,7 @@ class SafeManifest:
             [
                 'dataObject[@ID="S2_Level-1C_Preview_Tile1_Data"]/byteStream/fileLocation',
                 'dataObject[@ID="Preview_4_Tile1_Data"]/byteStream/fileLocation',
+                'dataObject[@ID="Preview_0_Tile1_Data"]/byteStream/fileLocation',
             ]
         )
 

--- a/src/stactools/sentinel2/stac.py
+++ b/src/stactools/sentinel2/stac.py
@@ -483,7 +483,7 @@ def metadata_from_safe_manifest(
     if safe_manifest.thumbnail_href is not None:
         extra_assets["preview"] = pystac.Asset(
             href=safe_manifest.thumbnail_href,
-            media_type=pystac.MediaType.COG,
+            media_type=product_metadata.image_media_type,
             roles=["thumbnail"],
         )
 

--- a/tests/data-files/S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135.SAFE/expected_output.json
+++ b/tests/data-files/S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135.SAFE/expected_output.json
@@ -823,6 +823,13 @@
       "roles": [
         "metadata"
       ]
+    },
+    "preview": {
+      "href": "./GRANULE/L1C_T01LAC_A026481_20200717T221944/QI_DATA/T01LAC_20200717T221941_PVI.jp2",
+      "type": "image/jp2",
+      "roles": [
+        "thumbnail"
+      ]
     }
   },
   "bbox": [

--- a/tests/data-files/S2A_MSIL1C_20210908T042701_N0301_R133_T46RER_20210908T070248.SAFE/expected_output.json
+++ b/tests/data-files/S2A_MSIL1C_20210908T042701_N0301_R133_T46RER_20210908T070248.SAFE/expected_output.json
@@ -821,6 +821,13 @@
       "roles": [
         "metadata"
       ]
+    },
+    "preview": {
+      "href": "./GRANULE/L1C_T46RER_A032448_20210908T043714/QI_DATA/T46RER_20210908T042701_PVI.jp2",
+      "type": "image/jp2",
+      "roles": [
+        "thumbnail"
+      ]
     }
   },
   "bbox": [

--- a/tests/data-files/esa_S2B_MSIL2A_20210122T133229_N0214_R081_T22HBD_20210122T155500.SAFE/expected_output.json
+++ b/tests/data-files/esa_S2B_MSIL2A_20210122T133229_N0214_R081_T22HBD_20210122T155500.SAFE/expected_output.json
@@ -1770,7 +1770,7 @@
     },
     "preview": {
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/QI_DATA/T22HBD_20210122T133229_PVI.jp2",
-      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "type": "image/jp2",
       "roles": [
         "thumbnail"
       ]


### PR DESCRIPTION
L1C preview file location is under ID Preview_0_Tile1_Data in [L1C manifest.safe](https://github.com/stactools-packages/sentinel2/blob/b033afa5d2afbba40e4da1ebe2033b537f6361ce/tests/data-files/S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135.SAFE/manifest.safe#L867), although it is under ID Preview_4_Tile1_Data in [ESA manifest.safe](https://github.com/stactools-packages/sentinel2/blob/b033afa5d2afbba40e4d.a1ebe2033b537f6361ce/tests/data-files/esa_S2B_MSIL2A_20210122T133229_N0214_R081_T22HBD_20210122T155500.SAFE/manifest.safe#L1136).

Otherwise, it can be found in granule metadata at tag PVI_FILENAME in both L1C and L2A SAFE formats.