### PR TITLE
change thumbnail getter from safe_manifest to granule_metadata

### DIFF
--- a/src/stactools/sentinel2/granule_metadata.py
+++ b/src/stactools/sentinel2/granule_metadata.py
@@ -229,7 +229,7 @@ class GranuleMetadata:
 
     @property
     def pvi_filename(self) -> Optional[str]:
-        return self._root.find_text('n1:Quality_Indicators_Info/PVI_FILENAME')
+        return self._root.find_text("n1:Quality_Indicators_Info/PVI_FILENAME")
 
     def create_asset(self):
         asset = pystac.Asset(

--- a/src/stactools/sentinel2/granule_metadata.py
+++ b/src/stactools/sentinel2/granule_metadata.py
@@ -227,6 +227,10 @@ class GranuleMetadata:
             return mgrs_match.group(1)
         return None
 
+    @property
+    def pvi_filename(self) -> Optional[str]:
+        return self._root.find_text('n1:Quality_Indicators_Info/PVI_FILENAME')
+
     def create_asset(self):
         asset = pystac.Asset(
             href=self.href, media_type=pystac.MediaType.XML, roles=["metadata"]

--- a/src/stactools/sentinel2/safe_manifest.py
+++ b/src/stactools/sentinel2/safe_manifest.py
@@ -41,16 +41,6 @@ class SafeManifest:
             return os.path.join(self.granule_href, file_path)
 
     @property
-    def thumbnail_href(self) -> Optional[str]:
-        return self._find_href(
-            [
-                'dataObject[@ID="S2_Level-1C_Preview_Tile1_Data"]/byteStream/fileLocation',
-                'dataObject[@ID="Preview_4_Tile1_Data"]/byteStream/fileLocation',
-                'dataObject[@ID="Preview_0_Tile1_Data"]/byteStream/fileLocation',
-            ]
-        )
-
-    @property
     def product_metadata_href(self) -> Optional[str]:
         return self._find_href(
             [

--- a/src/stactools/sentinel2/stac.py
+++ b/src/stactools/sentinel2/stac.py
@@ -480,9 +480,9 @@ def metadata_from_safe_manifest(
         ]
     )
 
-    if safe_manifest.thumbnail_href is not None:
+    if granule_metadata.pvi_filename is not None:
         extra_assets["preview"] = pystac.Asset(
-            href=safe_manifest.thumbnail_href,
+            href=os.path.join(granule_href, granule_metadata.pvi_filename),
             media_type=product_metadata.image_media_type,
             roles=["thumbnail"],
         )


### PR DESCRIPTION
Preview filename was get from manifest.safe but under different tags depending on the distributor.

However, the preview filename is well defined in [S2-PDGS-TAS-DI-PSD-V14.9.pdf](https://sentinel.esa.int/documents/247904/4756619/S2-PDGS-TAS-DI-PSD-V14.9.pdf/3d3b6c9c-4334-dcc4-3aa7-f7c0deffbaf7) (pages 272-273) in the granule metadata under the tag PVI_FILENAME.

Thus, the thumbnail getter was transfered from class SafeManifest to class GranuleMetadata and renamed "pvi_filename" according to its tag.