### PR TITLE
release v0.2.1

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project attempts to match the major and minor versions of [stactools](https://github.com/stac-utils/stactools) and increments the patch number as needed.
 
-## Unreleased
+## [Unreleased]
 
 Nothing
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,15 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project attempts to match the major and minor versions of [stactools](https://github.com/stac-utils/stactools) and increments the patch number as needed.
 
-## 0.2.1
+## Unreleased
+
+Nothing
+
+## [0.2.1] - 2023-05-24
 
 ### Added
 
-- Antimeridian geometry correction option in `create_item` ([]())
+- `antimeridian_strategy` option to `create_item` to split or normalize Item geometries that cross the antimeridian ([#99](https://github.com/stactools-packages/sentinel2/pull/99))
+- `coordinate_precision` option to `create_item` to round Item geometry coordinates and bbox values ([#99](https://github.com/stactools-packages/sentinel2/pull/99))
 
-## 0.2.0
+## [0.2.0] - 2021-07-21
 
 ### Changed
 
 - Modified Item IDs to include product discriminator ([#7](https://github.com/stactools-packages/sentinel2/pull/7))
 - Upgrade to stactools 0.2.1.a2 (supporting PySTAC 1.0.0)
+
+[Unreleased]: <https://github.com/stactools-packages/sentinel2/compare/v0.2.1..v0.2>
+[0.2.1]: <https://github.com/stactools-packages/sentinel2/compare/v0.2.0..v0.2.1>
+[0.2.0]: <https://github.com/stactools-packages/sentinel2/releases/tag/v0.2.0>

--- a/src/stactools/sentinel2/__init__.py
+++ b/src/stactools/sentinel2/__init__.py
@@ -11,4 +11,4 @@ def register_plugin(registry):
     registry.register_subcommand(commands.create_sentinel2_command)
 
 
-__version__ = '0.2.0'
+__version__ = "0.2.1"


### PR DESCRIPTION
**v0.2.1**

Added

- `antimeridian_strategy` option to `create_item` to split or normalize Item geometries that cross the antimeridian ([#99](https://github.com/stactools-packages/sentinel2/pull/99))
- `coordinate_precision` option to `create_item` to round Item geometry coordinates and bbox values ([#99](https://github.com/stactools-packages/sentinel2/pull/99))