### PR TITLE
Include product_metadata asset when working from granule_metadata

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Related issues
+
+- Closes #XXX
+- Unblocks #XXX
+
+## Description
+
+Please describe your changes.
+
+## Checklist
+
+- [ ] Includes tests
+- [ ] Includes documentation
+- [ ] Updates CHANGELOG

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project attempts to match the major and minor versions of [stactools](https://github.com/stac-utils/stactools) and increments the patch number as needed.
 
+## [Unreleased]
+
+### Added
+
+- `product_metadata` asset ([#117](https://github.com/stactools-packages/sentinel2/pull/117))
+
 ## [0.4.2] - 2023-07-03
 
 ## Fixed

--- a/src/stactools/sentinel2/stac.py
+++ b/src/stactools/sentinel2/stac.py
@@ -575,6 +575,9 @@ def metadata_from_granule_metadata(
             tileinfo_metadata.create_asset(),
         ]
     )
+    if product_metadata:
+        key, asset = product_metadata.create_asset()
+        extra_assets[key] = asset
 
     image_paths = (
         L2A_IMAGE_PATHS if "_L2A_" in granule_metadata.scene_id else L1C_IMAGE_PATHS

--- a/tests/data-files/S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBQ/expected_output.json
+++ b/tests/data-files/S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBQ/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBQ",
   "properties": {
-    "created": "2023-07-13T15:45Z",
+    "created": "2023-08-21T14:46Z",
     "providers": [
       {
         "name": "ESA",
@@ -1820,6 +1820,13 @@
     "tileinfo_metadata": {
       "href": "./tileInfo.json",
       "type": "application/json",
+      "roles": [
+        "metadata"
+      ]
+    },
+    "product_metadata": {
+      "href": "./product_metadata.xml",
+      "type": "application/xml",
       "roles": [
         "metadata"
       ]

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1,0 +1,10 @@
+from stactools.sentinel2 import stac
+
+from . import test_data
+
+
+def test_product_metadata_asset() -> None:
+    file_name = "S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBQ"
+    path = test_data.get_path(f"data-files/{file_name}")
+    item = stac.create_item(path)
+    assert "product_metadata" in item.assets


### PR DESCRIPTION
It was being dropped (and currently is not included in earth-search).