### PR TITLE
fix created property format, update stactools dep to 0.5.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,17 +3,17 @@
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.11.0
     hooks:
       - id: black
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.5
+    rev: v2.2.6
     hooks:
       - id: codespell
         args: [--ignore-words=.codespellignore]
         types_or: [jupyter, markdown, python, shell]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.6.1
     hooks:
       - id: mypy
         # TODO lint test and scripts too
@@ -29,6 +29,6 @@ repos:
           - pystac
           - types-requests
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.285
+    rev: v0.1.4
     hooks:
       - id: ruff

--- a/examples/sentinel2-l1c-example/S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135/S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135.json
+++ b/examples/sentinel2-l1c-example/S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135/S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135",
   "properties": {
-    "created": "2023-10-17T13:51Z",
+    "created": "2023-10-17T00:13:51Z",
     "providers": [
       {
         "name": "ESA",

--- a/examples/sentinel2-l2a-example/S2A_MSIL2A_20190212T192651_R013_T07HFE_20201007T160857/S2A_MSIL2A_20190212T192651_R013_T07HFE_20201007T160857.json
+++ b/examples/sentinel2-l2a-example/S2A_MSIL2A_20190212T192651_R013_T07HFE_20201007T160857/S2A_MSIL2A_20190212T192651_R013_T07HFE_20201007T160857.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_MSIL2A_20190212T192651_R013_T07HFE_20201007T160857",
   "properties": {
-    "created": "2023-10-17T13:51Z",
+    "created": "2023-10-17T00:13:51Z",
     "providers": [
       {
         "name": "ESA",

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ package_dir =
 packages = find_namespace:
 install_requires =
     antimeridian >= 0.3.3
-    stactools >= 0.4.8
+    stactools >= 0.5.2
     pystac >= 1.7.1
 
 [options.packages.find]

--- a/src/stactools/sentinel2/stac.py
+++ b/src/stactools/sentinel2/stac.py
@@ -15,6 +15,7 @@ from pystac.extensions.projection import ProjectionExtension
 from pystac.extensions.raster import DataType, RasterBand, RasterExtension
 from pystac.extensions.sat import OrbitState, SatExtension
 from pystac.extensions.view import ViewExtension
+from pystac.utils import now_to_rfc3339_str
 from shapely.geometry import mapping as shapely_mapping
 from shapely.geometry import shape as shapely_shape
 from shapely.validation import make_valid
@@ -128,7 +129,8 @@ def create_item(
         metadata = metadata_from_granule_metadata(
             granule_href, read_href_modifier, tolerance
         )
-    created = datetime.now().strftime("%Y-%m-%dT%H:%MZ")
+
+    created = now_to_rfc3339_str()
 
     # ensure that we have a valid geometry, fixing any antimeridian issues
     geometry = shapely_mapping(

--- a/tests/data-files/S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135.SAFE/expected_output.json
+++ b/tests/data-files/S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135",
   "properties": {
-    "created": "2023-09-18T12:28Z",
+    "created": "2023-09-18T12:28:00Z",
     "providers": [
       {
         "name": "ESA",

--- a/tests/data-files/S2A_MSIL1C_20210908T042701_N0301_R133_T46RER_20210908T070248.SAFE/expected_output.json
+++ b/tests/data-files/S2A_MSIL1C_20210908T042701_N0301_R133_T46RER_20210908T070248.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_MSIL1C_20210908T042701_R133_T46RER_20210908T070248",
   "properties": {
-    "created": "2023-09-18T12:28Z",
+    "created": "2023-09-18T12:28:00Z",
     "providers": [
       {
         "name": "ESA",

--- a/tests/data-files/S2A_MSIL2A_20190212T192651_N0212_R013_T07HFE_20201007T160857.SAFE/expected_output.json
+++ b/tests/data-files/S2A_MSIL2A_20190212T192651_N0212_R013_T07HFE_20201007T160857.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_MSIL2A_20190212T192651_R013_T07HFE_20201007T160857",
   "properties": {
-    "created": "2023-09-18T12:28Z",
+    "created": "2023-09-18T12:28:00Z",
     "providers": [
       {
         "name": "ESA",

--- a/tests/data-files/S2A_MSIL2A_20230625T234621_N0509_R073_T01WCP_20230626T022157.SAFE/expected_output.json
+++ b/tests/data-files/S2A_MSIL2A_20230625T234621_N0509_R073_T01WCP_20230626T022157.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_MSIL2A_20230625T234621_R073_T01WCP_20230626T022157",
   "properties": {
-    "created": "2023-09-18T12:28Z",
+    "created": "2023-09-18T12:28:00Z",
     "providers": [
       {
         "name": "ESA",

--- a/tests/data-files/S2A_MSIL2A_20230625T234621_N0509_R073_T01WCP_20230626T022158.SAFE/expected_output.json
+++ b/tests/data-files/S2A_MSIL2A_20230625T234621_N0509_R073_T01WCP_20230626T022158.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_MSIL2A_20230625T234621_R073_T01WCP_20230626T022158",
   "properties": {
-    "created": "2023-09-18T12:28Z",
+    "created": "2023-09-18T12:28:00Z",
     "providers": [
       {
         "name": "ESA",

--- a/tests/data-files/S2A_MSIL2A_20230625T234621_N0509_R073_T01WCS_20230626T022157.SAFE/expected_output.json
+++ b/tests/data-files/S2A_MSIL2A_20230625T234621_N0509_R073_T01WCS_20230626T022157.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_MSIL2A_20230625T234621_R073_T01WCS_20230626T022157",
   "properties": {
-    "created": "2023-09-18T12:28Z",
+    "created": "2023-09-18T12:28:00Z",
     "providers": [
       {
         "name": "ESA",

--- a/tests/data-files/S2A_MSIL2A_20230821T221941_N0509_R029_T01KAB_20230822T021825.SAFE/expected_output.json
+++ b/tests/data-files/S2A_MSIL2A_20230821T221941_N0509_R029_T01KAB_20230822T021825.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_MSIL2A_20230821T221941_R029_T01KAB_20230822T021825",
   "properties": {
-    "created": "2023-09-18T12:28Z",
+    "created": "2023-09-18T12:28:00Z",
     "providers": [
       {
         "name": "ESA",

--- a/tests/data-files/S2A_OPER_MSI_L1C_TL_SGS__20181231T203637_A018414_T10SDG/expected_output.json
+++ b/tests/data-files/S2A_OPER_MSI_L1C_TL_SGS__20181231T203637_A018414_T10SDG/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_OPER_MSI_L1C_TL_SGS__20181231T203637_A018414_T10SDG",
   "properties": {
-    "created": "2023-09-18T12:28Z",
+    "created": "2023-09-18T12:28:00Z",
     "providers": [
       {
         "name": "ESA",

--- a/tests/data-files/S2A_OPER_MSI_L2A_TL_SGS__20181231T210250_A018414_T10SDG/expected_output.json
+++ b/tests/data-files/S2A_OPER_MSI_L2A_TL_SGS__20181231T210250_A018414_T10SDG/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_OPER_MSI_L2A_TL_SGS__20181231T210250_A018414_T10SDG",
   "properties": {
-    "created": "2023-09-18T12:28Z",
+    "created": "2023-09-18T12:28:00Z",
     "providers": [
       {
         "name": "ESA",

--- a/tests/data-files/S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBP/expected_output.json
+++ b/tests/data-files/S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBP/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBP",
   "properties": {
-    "created": "2023-09-18T12:28Z",
+    "created": "2023-09-18T12:28:00Z",
     "providers": [
       {
         "name": "ESA",

--- a/tests/data-files/S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBQ/expected_output.json
+++ b/tests/data-files/S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBQ/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBQ",
   "properties": {
-    "created": "2023-09-18T12:28Z",
+    "created": "2023-09-18T12:28:00Z",
     "providers": [
       {
         "name": "ESA",

--- a/tests/data-files/S2B_MSIL2A_20191228T210519_N0212_R071_T01CCV_20201003T104658.SAFE/expected_output.json
+++ b/tests/data-files/S2B_MSIL2A_20191228T210519_N0212_R071_T01CCV_20201003T104658.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2B_MSIL2A_20191228T210519_R071_T01CCV_20201003T104658",
   "properties": {
-    "created": "2023-09-18T12:28Z",
+    "created": "2023-09-18T12:28:00Z",
     "providers": [
       {
         "name": "ESA",

--- a/tests/data-files/S2B_MSIL2A_20220413T150759_N0400_R025_T33XWJ_20220414T082126.SAFE/expected_output.json
+++ b/tests/data-files/S2B_MSIL2A_20220413T150759_N0400_R025_T33XWJ_20220414T082126.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2B_MSIL2A_20220413T150759_R025_T33XWJ_20220414T082126",
   "properties": {
-    "created": "2023-09-18T12:28Z",
+    "created": "2023-09-18T12:28:00Z",
     "providers": [
       {
         "name": "ESA",

--- a/tests/data-files/esa_S2B_MSIL2A_20210122T133229_N0214_R081_T22HBD_20210122T155500.SAFE/expected_output.json
+++ b/tests/data-files/esa_S2B_MSIL2A_20210122T133229_N0214_R081_T22HBD_20210122T155500.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2B_MSIL2A_20210122T133229_R081_T22HBD_20210122T155500",
   "properties": {
-    "created": "2023-09-18T12:28Z",
+    "created": "2023-09-18T12:28:00Z",
     "providers": [
       {
         "name": "ESA",

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -123,6 +123,8 @@ def test_create_item(tmp_path: Path, item_id: str, file_name: str):
 
         return d
 
+    assert item.common_metadata.created is not None
+
     assert mk_comparable(item) == mk_comparable(
         pystac.Item.from_file(f"{granule_href}/expected_output.json")
     )


### PR DESCRIPTION
## Related issues

n/a

## Description

1. Fixes the population of the `created` field to have a valid RFC 3339 datetime. Previously, the string was missing the seconds.
2. Fixes all of the examples that had this invalid datetime string.
3. Update stactools dependency to require at least 0.5.2, as the reproject_shape was not added until v0.5.2 in `Enforce that shapely be >=2.0.0 and unify reproject_* by @jsignell in https://github.com/stac-utils/stactools/pull/441`
4. Update all pre-commit versions

## Checklist

- [X] Includes tests
- [X] Includes documentation
- [X] Updates CHANGELOG
