### PR TITLE
drop python 3.8 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11"]
     defaults:
       run:
         shell: bash -l {0}

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - The convention for naming the STAC Items has changed. ([#131](https://github.com/stactools-packages/sentinel2/pull/131)). A full explanation given in [Issue #130](https://github.com/stactools-packages/sentinel2/issues/130)
+- Drop support for Python 3.9
+- Require pystac >= 1.9.0
 
 ## [0.4.2] - 2023-07-03
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ packages = find_namespace:
 install_requires =
     antimeridian >= 0.3.3
     stactools >= 0.5.2
-    pystac >= 1.7.1
+    pystac >= 1.9.0
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,13 +17,13 @@ keywords =
 classifiers =
     Development Status :: 4 - Beta
     License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 
 [options]
-python_requires = >=3.8
+python_requires = >=3.9
 package_dir =
     = src
 packages = find_namespace:

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
 
 [options]
 python_requires = >=3.9


### PR DESCRIPTION
## Related issues

- n/a

## Description

1. Drop support for Python 3.8
2. ~Add support for Python 3.12~
3. Update requirement for pystac >= 1.9

## Checklist

- [X] Includes tests
- [X] Includes documentation
- [X] Updates CHANGELOG
