### PR TITLE
release prep for 0.5.0-pre1 release

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project attempts to match the major and minor versions of [stactools](https://github.com/stac-utils/stactools) and increments the patch number as needed.
 
-## [Unreleased]
+## [0.5.0] - TBD
 
 ### Added
 
@@ -86,7 +86,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Modified Item IDs to include product discriminator ([#7](https://github.com/stactools-packages/sentinel2/pull/7))
 - Upgrade to stactools 0.2.1.a2 (supporting PySTAC 1.0.0)
 
-[Unreleased]: <https://github.com/stactools-packages/sentinel2/compare/v0.4.2..main>
+<!-- [Unreleased]: <https://github.com/stactools-packages/sentinel2/compare/v0.4.2..main> -->
+[0.5.0]: <https://github.com/stactools-packages/sentinel2/compare/v0.4.2..v0.5.0>
 [0.4.2]: <https://github.com/stactools-packages/sentinel2/compare/v0.4.1..v0.4.2>
 [0.4.1]: <https://github.com/stactools-packages/sentinel2/compare/v0.4.0..v0.4.1>
 [0.4.0]: <https://github.com/stactools-packages/sentinel2/compare/v0.3.0..v0.4.0>

--- a/src/stactools/sentinel2/__init__.py
+++ b/src/stactools/sentinel2/__init__.py
@@ -11,4 +11,4 @@ def register_plugin(registry):
     registry.register_subcommand(commands.create_sentinel2_command)
 
 
-__version__ = "0.5.0-pre1"
+__version__ = "0.5.0a1"

--- a/src/stactools/sentinel2/__init__.py
+++ b/src/stactools/sentinel2/__init__.py
@@ -11,4 +11,4 @@ def register_plugin(registry):
     registry.register_subcommand(commands.create_sentinel2_command)
 
 
-__version__ = "0.4.2"
+__version__ = "0.5.0-pre1"


### PR DESCRIPTION
## Related issues

## Description

- release prep for 0.5.0-pre1 release

## Checklist

- [X] Includes tests
- [X] Includes documentation
- [X] Updates CHANGELOG
