### PR TITLE
add the PVI image to assets

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The convention for naming the STAC Items has changed. ([#131](https://github.com/stactools-packages/sentinel2/pull/131)). A full explanation given in [Issue #130](https://github.com/stactools-packages/sentinel2/issues/130)
 - pystac >= 1.9.0 is now required
 - Names in eo:bands structure are now S2 band names, not common name ([#139](https://github.com/stactools-packages/sentinel2/pull/139))
+- PVI asset role changed from "thumbnail" or "visual" to "overview" ([#143](https://github.com/stactools-packages/sentinel2/pull/143))
 
 ### Removed
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -13,8 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `product_metadata` asset ([#117](https://github.com/stactools-packages/sentinel2/pull/117))
 - Examples ([#124](https://github.com/stactools-packages/sentinel2/pull/124))
 - `cloud` and `snow` assets ([#129](https://github.com/stactools-packages/sentinel2/pull/129))
-- gsd for ancillary assets (e.g., aot, wvp, etc) ([#139](https://github.com/stactools-packages/sentinel2/pull/139)) 
+- gsd for ancillary assets (e.g., aot, wvp, etc) ([#139](https://github.com/stactools-packages/sentinel2/pull/139))
 - Mean values for sensor azimuth and incidence angle in Item properties ([#137](https://github.com/stactools-packages/sentinel2/pull/141))
+- Add PVI asset as "preview" for Sentinel-2 L2A ([#143](https://github.com/stactools-packages/sentinel2/pull/143))
 
 ### Fixed
 

--- a/examples/sentinel2-l1c-example/S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135/S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135.json
+++ b/examples/sentinel2-l1c-example/S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135/S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135.json
@@ -854,7 +854,7 @@
       "href": "../../../tests/data-files/S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135.SAFE/GRANULE/L1C_T01LAC_A026481_20200717T221944/QI_DATA/T01LAC_20200717T221941_PVI.jp2",
       "type": "image/jp2",
       "roles": [
-        "thumbnail"
+        "overview"
       ]
     }
   },

--- a/examples/sentinel2-l2a-example/S2A_MSIL2A_20190212T192651_R013_T07HFE_20201007T160857/S2A_MSIL2A_20190212T192651_R013_T07HFE_20201007T160857.json
+++ b/examples/sentinel2-l2a-example/S2A_MSIL2A_20190212T192651_R013_T07HFE_20201007T160857/S2A_MSIL2A_20190212T192651_R013_T07HFE_20201007T160857.json
@@ -1770,7 +1770,7 @@
       "href": "../../../tests/data-files/S2A_MSIL2A_20190212T192651_N0212_R013_T07HFE_20201007T160857.SAFE/GRANULE/L2A_T07HFE_A019029_20190212T192646/QI_DATA/T07HFE_20190212T192651_PVI.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "roles": [
-        "thumbnail"
+        "overview"
       ]
     }
   },

--- a/src/stactools/sentinel2/constants.py
+++ b/src/stactools/sentinel2/constants.py
@@ -211,6 +211,7 @@ L2A_IMAGE_PATHS: Final[list[str]] = [
     "R60m/B08.jp2",
     "qi/CLD_20m.jp2",
     "qi/SNW_20m.jp2",
+    "qi/L2A_PVI.jp2",
 ]
 
 L1C_IMAGE_PATHS: Final[list[str]] = [

--- a/src/stactools/sentinel2/stac.py
+++ b/src/stactools/sentinel2/stac.py
@@ -277,13 +277,13 @@ def image_asset_from_href(
             href=asset_href,
             media_type=asset_media_type,
             title="True color preview",
-            roles=["visual"],
+            roles=["overview"],
         )
         asset_eo = EOExtension.ext(asset)
         asset_eo.bands = RGB_BANDS
         return "preview", asset
 
-    if THUMBNAIL_PATTERN.search(asset_href):
+    elif THUMBNAIL_PATTERN.search(asset_href):
         # thumbnail image
         asset = pystac.Asset(
             href=asset_href,
@@ -542,7 +542,7 @@ def metadata_from_safe_manifest(
         extra_assets["preview"] = pystac.Asset(
             href=os.path.join(granule_href, granule_metadata.pvi_filename),
             media_type=product_metadata.image_media_type,
-            roles=["thumbnail"],
+            roles=["overview"],
         )
 
     return Metadata(

--- a/src/stactools/sentinel2/stac.py
+++ b/src/stactools/sentinel2/stac.py
@@ -282,7 +282,8 @@ def image_asset_from_href(
         asset_eo = EOExtension.ext(asset)
         asset_eo.bands = RGB_BANDS
         return "preview", asset
-    elif THUMBNAIL_PATTERN.search(asset_href):
+
+    if THUMBNAIL_PATTERN.search(asset_href):
         # thumbnail image
         asset = pystac.Asset(
             href=asset_href,

--- a/tests/data-files/S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135.SAFE/expected_output.json
+++ b/tests/data-files/S2A_MSIL1C_20200717T221941_R029_T01LAC_20200717T234135.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_T01LAC_20200717T221944_L1C",
   "properties": {
-    "created": "2023-11-17T21:03:58.948575Z",
+    "created": "2023-11-20T17:22:07.294960Z",
     "providers": [
       {
         "name": "ESA",
@@ -786,7 +786,7 @@
       "href": "./GRANULE/L1C_T01LAC_A026481_20200717T221944/QI_DATA/T01LAC_20200717T221941_PVI.jp2",
       "type": "image/jp2",
       "roles": [
-        "thumbnail"
+        "overview"
       ]
     }
   },

--- a/tests/data-files/S2A_MSIL1C_20210908T042701_N0301_R133_T46RER_20210908T070248.SAFE/expected_output.json
+++ b/tests/data-files/S2A_MSIL1C_20210908T042701_N0301_R133_T46RER_20210908T070248.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_T46RER_20210908T043714_L1C",
   "properties": {
-    "created": "2023-11-17T21:03:58.526452Z",
+    "created": "2023-11-20T17:22:06.991764Z",
     "providers": [
       {
         "name": "ESA",
@@ -776,7 +776,7 @@
       "href": "./GRANULE/L1C_T46RER_A032448_20210908T043714/QI_DATA/T46RER_20210908T042701_PVI.jp2",
       "type": "image/jp2",
       "roles": [
-        "thumbnail"
+        "overview"
       ]
     }
   },

--- a/tests/data-files/S2A_MSIL2A_20190212T192651_N0212_R013_T07HFE_20201007T160857.SAFE/expected_output.json
+++ b/tests/data-files/S2A_MSIL2A_20190212T192651_N0212_R013_T07HFE_20201007T160857.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_T07HFE_20190212T192646_L2A",
   "properties": {
-    "created": "2023-11-17T21:03:58.387630Z",
+    "created": "2023-11-20T17:22:06.896013Z",
     "providers": [
       {
         "name": "ESA",
@@ -1649,7 +1649,7 @@
       "href": "./GRANULE/L2A_T07HFE_A019029_20190212T192646/QI_DATA/T07HFE_20190212T192651_PVI.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "roles": [
-        "thumbnail"
+        "overview"
       ]
     }
   },

--- a/tests/data-files/S2A_MSIL2A_20230625T234621_N0509_R073_T01WCP_20230626T022157.SAFE/expected_output.json
+++ b/tests/data-files/S2A_MSIL2A_20230625T234621_N0509_R073_T01WCP_20230626T022157.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_T01WCP_20230625T234624_L2A",
   "properties": {
-    "created": "2023-11-17T21:03:58.098356Z",
+    "created": "2023-11-20T17:22:06.726429Z",
     "providers": [
       {
         "name": "ESA",
@@ -1707,7 +1707,7 @@
       "href": "./GRANULE/L2A_T01WCP_A041826_20230625T234624/QI_DATA/T01WCP_20230625T234621_PVI.jp2",
       "type": "image/jp2",
       "roles": [
-        "thumbnail"
+        "overview"
       ]
     }
   },

--- a/tests/data-files/S2A_MSIL2A_20230625T234621_N0509_R073_T01WCP_20230626T022158.SAFE/expected_output.json
+++ b/tests/data-files/S2A_MSIL2A_20230625T234621_N0509_R073_T01WCP_20230626T022158.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_T01WCP_20230625T234624_L2A",
   "properties": {
-    "created": "2023-11-17T21:03:58.585964Z",
+    "created": "2023-11-20T17:22:07.028165Z",
     "providers": [
       {
         "name": "ESA",
@@ -1705,7 +1705,7 @@
       "href": "./GRANULE/L2A_T01WCP_A041826_20230625T234624/QI_DATA/T01WCP_20230625T234621_PVI.jp2",
       "type": "image/jp2",
       "roles": [
-        "thumbnail"
+        "overview"
       ]
     }
   },

--- a/tests/data-files/S2A_MSIL2A_20230625T234621_N0509_R073_T01WCS_20230626T022157.SAFE/expected_output.json
+++ b/tests/data-files/S2A_MSIL2A_20230625T234621_N0509_R073_T01WCS_20230626T022157.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_T01WCS_20230625T234624_L2A",
   "properties": {
-    "created": "2023-11-17T21:03:58.725804Z",
+    "created": "2023-11-20T17:22:07.138030Z",
     "providers": [
       {
         "name": "ESA",
@@ -1735,7 +1735,7 @@
       "href": "./GRANULE/L2A_T01WCS_A041826_20230625T234624/QI_DATA/T01WCS_20230625T234621_PVI.jp2",
       "type": "image/jp2",
       "roles": [
-        "thumbnail"
+        "overview"
       ]
     }
   },

--- a/tests/data-files/S2A_MSIL2A_20230821T221941_N0509_R029_T01KAB_20230822T021825.SAFE/expected_output.json
+++ b/tests/data-files/S2A_MSIL2A_20230821T221941_N0509_R029_T01KAB_20230822T021825.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_T01KAB_20230821T221944_L2A",
   "properties": {
-    "created": "2023-11-17T21:03:58.248543Z",
+    "created": "2023-11-20T17:22:06.799537Z",
     "providers": [
       {
         "name": "ESA",
@@ -1707,7 +1707,7 @@
       "href": "./GRANULE/L2A_T01KAB_A042640_20230821T221944/QI_DATA/T01KAB_20230821T221941_PVI.jp2",
       "type": "image/jp2",
       "roles": [
-        "thumbnail"
+        "overview"
       ]
     }
   },

--- a/tests/data-files/S2A_OPER_MSI_L1C_TL_SGS__20181231T203637_A018414_T10SDG/expected_output.json
+++ b/tests/data-files/S2A_OPER_MSI_L1C_TL_SGS__20181231T203637_A018414_T10SDG/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_OPER_MSI_L1C_TL_SGS__20181231T203637_A018414_T10SDG",
   "properties": {
-    "created": "2023-11-17T21:03:59.001375Z",
+    "created": "2023-11-20T17:22:07.346802Z",
     "providers": [
       {
         "name": "ESA",

--- a/tests/data-files/S2A_OPER_MSI_L2A_TL_SGS__20181231T210250_A018414_T10SDG/expected_output.json
+++ b/tests/data-files/S2A_OPER_MSI_L2A_TL_SGS__20181231T210250_A018414_T10SDG/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_OPER_MSI_L2A_TL_SGS__20181231T210250_A018414_T10SDG",
   "properties": {
-    "created": "2023-11-17T21:03:58.658480Z",
+    "created": "2023-11-20T17:22:07.092086Z",
     "providers": [
       {
         "name": "ESA",
@@ -1772,7 +1772,7 @@
         }
       ],
       "roles": [
-        "visual"
+        "overview"
       ]
     },
     "granule_metadata": {

--- a/tests/data-files/S2A_OPER_MSI_L2A_TL_SGS__20181231T210250_A018414_T10SDG/expected_output.json
+++ b/tests/data-files/S2A_OPER_MSI_L2A_TL_SGS__20181231T210250_A018414_T10SDG/expected_output.json
@@ -1747,6 +1747,34 @@
         "snow-ice"
       ]
     },
+    "preview": {
+      "href": "./qi/L2A_PVI.jp2",
+      "type": "image/jp2",
+      "title": "True color preview",
+      "eo:bands": [
+        {
+          "name": "B04",
+          "common_name": "red",
+          "center_wavelength": 0.665,
+          "full_width_half_max": 0.038
+        },
+        {
+          "name": "B03",
+          "common_name": "green",
+          "center_wavelength": 0.56,
+          "full_width_half_max": 0.045
+        },
+        {
+          "name": "B02",
+          "common_name": "blue",
+          "center_wavelength": 0.49,
+          "full_width_half_max": 0.098
+        }
+      ],
+      "roles": [
+        "visual"
+      ]
+    },
     "granule_metadata": {
       "href": "./metadata.xml",
       "type": "application/xml",

--- a/tests/data-files/S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBP/expected_output.json
+++ b/tests/data-files/S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBP/expected_output.json
@@ -1747,6 +1747,34 @@
         "snow-ice"
       ]
     },
+    "preview": {
+      "href": "./qi/L2A_PVI.jp2",
+      "type": "image/jp2",
+      "title": "True color preview",
+      "eo:bands": [
+        {
+          "name": "B04",
+          "common_name": "red",
+          "center_wavelength": 0.665,
+          "full_width_half_max": 0.038
+        },
+        {
+          "name": "B03",
+          "common_name": "green",
+          "center_wavelength": 0.56,
+          "full_width_half_max": 0.045
+        },
+        {
+          "name": "B02",
+          "common_name": "blue",
+          "center_wavelength": 0.49,
+          "full_width_half_max": 0.098
+        }
+      ],
+      "roles": [
+        "visual"
+      ]
+    },
     "granule_metadata": {
       "href": "./metadata.xml",
       "type": "application/xml",

--- a/tests/data-files/S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBP/expected_output.json
+++ b/tests/data-files/S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBP/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBP",
   "properties": {
-    "created": "2023-11-17T21:03:57.104625Z",
+    "created": "2023-11-20T17:22:06.388489Z",
     "providers": [
       {
         "name": "ESA",
@@ -1772,7 +1772,7 @@
         }
       ],
       "roles": [
-        "visual"
+        "overview"
       ]
     },
     "granule_metadata": {

--- a/tests/data-files/S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBQ/expected_output.json
+++ b/tests/data-files/S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBQ/expected_output.json
@@ -1753,6 +1753,34 @@
         "snow-ice"
       ]
     },
+    "preview": {
+      "href": "./qi/L2A_PVI.jp2",
+      "type": "image/jp2",
+      "title": "True color preview",
+      "eo:bands": [
+        {
+          "name": "B04",
+          "common_name": "red",
+          "center_wavelength": 0.665,
+          "full_width_half_max": 0.038
+        },
+        {
+          "name": "B03",
+          "common_name": "green",
+          "center_wavelength": 0.56,
+          "full_width_half_max": 0.045
+        },
+        {
+          "name": "B02",
+          "common_name": "blue",
+          "center_wavelength": 0.49,
+          "full_width_half_max": 0.098
+        }
+      ],
+      "roles": [
+        "visual"
+      ]
+    },
     "granule_metadata": {
       "href": "./metadata.xml",
       "type": "application/xml",

--- a/tests/data-files/S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBQ/expected_output.json
+++ b/tests/data-files/S2A_OPER_MSI_L2A_TL_VGS1_20220401T110010_A035382_T34LBQ/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2A_T34LBQ_20220401T090142_L2A",
   "properties": {
-    "created": "2023-11-17T21:03:58.316133Z",
+    "created": "2023-11-20T17:22:06.849436Z",
     "providers": [
       {
         "name": "ESA",
@@ -1778,7 +1778,7 @@
         }
       ],
       "roles": [
-        "visual"
+        "overview"
       ]
     },
     "granule_metadata": {

--- a/tests/data-files/S2B_MSIL2A_20191228T210519_N0212_R071_T01CCV_20201003T104658.SAFE/expected_output.json
+++ b/tests/data-files/S2B_MSIL2A_20191228T210519_N0212_R071_T01CCV_20201003T104658.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2B_T01CCV_20191228T210521_L2A",
   "properties": {
-    "created": "2023-11-17T21:03:58.461967Z",
+    "created": "2023-11-20T17:22:06.943002Z",
     "providers": [
       {
         "name": "ESA",
@@ -1665,7 +1665,7 @@
       "href": "./GRANULE/L2A_T01CCV_A014683_20191228T210521/QI_DATA/T01CCV_20191228T210519_PVI.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "roles": [
-        "thumbnail"
+        "overview"
       ]
     }
   },

--- a/tests/data-files/S2B_MSIL2A_20220413T150759_N0400_R025_T33XWJ_20220414T082126.SAFE/expected_output.json
+++ b/tests/data-files/S2B_MSIL2A_20220413T150759_N0400_R025_T33XWJ_20220414T082126.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2B_T33XWJ_20220413T150756_L2A",
   "properties": {
-    "created": "2023-11-17T21:03:58.790610Z",
+    "created": "2023-11-20T17:22:07.188249Z",
     "providers": [
       {
         "name": "ESA",
@@ -1681,7 +1681,7 @@
       "href": "./GRANULE/L2A_T33XWJ_A026649_20220413T150756/QI_DATA/T33XWJ_20220413T150759_PVI.tif",
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "roles": [
-        "thumbnail"
+        "overview"
       ]
     }
   },

--- a/tests/data-files/esa_S2B_MSIL2A_20210122T133229_N0214_R081_T22HBD_20210122T155500.SAFE/expected_output.json
+++ b/tests/data-files/esa_S2B_MSIL2A_20210122T133229_N0214_R081_T22HBD_20210122T155500.SAFE/expected_output.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "S2B_T22HBD_20210122T133224_L2A",
   "properties": {
-    "created": "2023-11-17T21:03:58.873180Z",
+    "created": "2023-11-20T17:22:07.238242Z",
     "providers": [
       {
         "name": "ESA",
@@ -1669,7 +1669,7 @@
       "href": "./GRANULE/L2A_T22HBD_A020270_20210122T133224/QI_DATA/T22HBD_20210122T133229_PVI.jp2",
       "type": "image/jp2",
       "roles": [
-        "thumbnail"
+        "overview"
       ]
     }
   },


### PR DESCRIPTION
## Related issues

n/a

## Description

1. Add PVI asset. Code was already in there to add it, but it wasn't one of the assets that was processed.
2. PVI asset role changed from visual to overview, per STAC Asset best practices doc

## Checklist

- [X] Includes tests
- [X] Includes documentation
- [X] Updates CHANGELOG
