### PR TITLE
use reproject_shape instead of reproject_geom (deprecated)

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project attempts to match the major and minor versions of [stactools](https://github.com/stac-utils/stactools) and increments the patch number as needed.
 
+## [Unreleased] - TBD
+
+### Changed
+
+- use reproject_shape instead of reproject_geom (deprecated)
+
 ## [0.6.0] - 2023-12-13
 
 ### Fixed
@@ -107,7 +113,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Modified Item IDs to include product discriminator ([#7](https://github.com/stactools-packages/sentinel2/pull/7))
 - Upgrade to stactools 0.2.1.a2 (supporting PySTAC 1.0.0)
 
-<!-- [Unreleased]: <https://github.com/stactools-packages/sentinel2/compare/v0.4.2..main> -->
+[Unreleased]: <https://github.com/stactools-packages/sentinel2/compare/v0.4.2..main>
 [0.6.0]: <https://github.com/stactools-packages/sentinel2/compare/v0.5.0..v0.6.0>
 [0.5.0]: <https://github.com/stactools-packages/sentinel2/compare/v0.4.2..v0.5.0>
 [0.4.2]: <https://github.com/stactools-packages/sentinel2/compare/v0.4.1..v0.4.2>

--- a/src/stactools/sentinel2/stac.py
+++ b/src/stactools/sentinel2/stac.py
@@ -22,7 +22,7 @@ from shapely.geometry import mapping as shapely_mapping
 from shapely.geometry import shape as shapely_shape
 from shapely.validation import make_valid
 from stactools.core.io import ReadHrefModifier
-from stactools.core.projection import reproject_geom, transform_from_bbox
+from stactools.core.projection import reproject_shape, transform_from_bbox
 from stactools.sentinel2.constants import (
     ASSET_TO_TITLE,
     BANDS_TO_ASSET_NAME,
@@ -578,10 +578,8 @@ def metadata_from_granule_metadata(
         )
         product_metadata = ProductMetadata(f, read_href_modifier)
 
-    geometry = shapely_shape(
-        reproject_geom(
-            f"epsg:{granule_metadata.epsg}", "epsg:4326", tileinfo_metadata.geometry
-        )
+    geometry = reproject_shape(
+        f"epsg:{granule_metadata.epsg}", "epsg:4326", tileinfo_metadata.geometry
     ).simplify(tolerance)
 
     extra_assets = dict(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -18,7 +18,7 @@ from pystac.extensions.projection import ProjectionExtension
 from pystac.extensions.view import ViewExtension
 from pystac.utils import is_absolute_href
 from shapely.geometry import box, mapping, shape
-from stactools.core.projection import reproject_geom
+from stactools.core.projection import reproject_shape
 from stactools.sentinel2.commands import create_sentinel2_command
 from stactools.sentinel2.constants import (
     COORD_ROUNDING,
@@ -72,7 +72,7 @@ def proj_bbox_area_difference(item):
     visual_asset = item.assets.get("visual_10m") or item.assets.get("visual")
     asset_projection = ProjectionExtension.ext(visual_asset)
     pb = mapping(box(*asset_projection.bbox))
-    proj_geom = shape(reproject_geom(f"epsg:{projection.epsg}", "epsg:4326", pb))
+    proj_geom = reproject_shape(f"epsg:{projection.epsg}", "epsg:4326", pb)
 
     item_geom = shape(item.geometry)
 


### PR DESCRIPTION
## Related issues

n/a

## Description

use reproject_shape instead of reproject_geom (deprecated)

## Checklist

- [X] Includes tests
- [X] Includes documentation
- [X] Updates CHANGELOG
