### PR TITLE
Release prep v0.7.0

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project attempts to match the major and minor versions of [stactools](https://github.com/stac-utils/stactools) and increments the patch number as needed.
 
-## [Unreleased]
+## [0.7.0] - 2025-05-28
 
 ### Added
 
@@ -158,7 +158,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Modified Item IDs to include product discriminator ([#7](https://github.com/stactools-packages/sentinel2/pull/7))
 - Upgrade to stactools 0.2.1.a2 (supporting PySTAC 1.0.0)
 
-[Unreleased]: <https://github.com/stactools-packages/sentinel2/compare/v0.6.5..main>
+[Unreleased]: <https://github.com/stactools-packages/sentinel2/compare/v0.7.0..main>
+[0.7.0]: <https://github.com/stactools-packages/sentinel2/compare/v0.6.5..v0.7.0>
 [0.6.5]: <https://github.com/stactools-packages/sentinel2/compare/v0.6.4..v0.6.5>
 [0.6.4]: <https://github.com/stactools-packages/sentinel2/compare/v0.6.3..v0.6.4>
 [0.6.3]: <https://github.com/stactools-packages/sentinel2/compare/v0.6.2..v0.6.3>

--- a/src/stactools/sentinel2/__init__.py
+++ b/src/stactools/sentinel2/__init__.py
@@ -11,4 +11,4 @@ def register_plugin(registry):
     registry.register_subcommand(commands.create_sentinel2_command)
 
 
-__version__ = "0.6.5"
+__version__ = "0.7.0"


### PR DESCRIPTION
## [0.7.0] - 2025-05-28

### Added

- Added `allow_fallback_geometry` option to create stac, that allows usage of product
  metadata geometry if data is not found in AWS tileInfo metadata

### Changed

- Updated project configuration to use only `pyproject.toml`
- Updated `grid.code` to include leading zeros on UTM zones less than 10.
  ([#188](https://github.com/stactools-packages/sentinel2/issues/188))
- Use shapely `transform` instead of `reproject_shape` reproject to EPSG:4326

